### PR TITLE
Temporarily override the get method for the PyG datasets to fix issue #10

### DIFF
--- a/autogl/datasets/__init__.py
+++ b/autogl/datasets/__init__.py
@@ -1,5 +1,4 @@
 import os.path as osp
-import importlib
 import os
 import torch
 from ..data.dataset import Dataset
@@ -8,6 +7,7 @@ from ..data.dataset import Dataset
 try:
     import torch_geometric
 except ImportError:
+    torch_geometric = None
     pyg = False
 else:
     pyg = True
@@ -56,15 +56,15 @@ from .pyg import (
     PubMedDataset,
     RedditDataset,
     MUTAGDataset,
-    ImdbBinaryDataset,
-    ImdbMultiDataset,
+    IMDBBinaryDataset,
+    IMDBMultiDataset,
     CollabDataset,
-    ProtainsDataset,
-    RedditBinary,
-    RedditMulti5K,
-    RedditMulti12K,
+    ProteinsDataset,
+    REDDITBinary,
+    REDDITMulti5K,
+    REDDITMulti12K,
     PTCMRDataset,
-    NCT1Dataset,
+    NCI1Dataset,
     ENZYMES,
     QM9Dataset,
 )
@@ -95,7 +95,11 @@ from .matlab_matrix import (
     WikipediaDataset,
     PPIDataset,
 )
-from .modelnet import ModelNet10, ModelNet40, ModelNetData10, ModelNetData40
+from .modelnet import (
+    ModelNet10, ModelNet40,
+    ModelNet10Train, ModelNet10Test,
+    ModelNet40Train, ModelNet40Test
+)
 from .utils import (
     get_label_number,
     random_splits_mask,

--- a/autogl/datasets/modelnet.py
+++ b/autogl/datasets/modelnet.py
@@ -1,92 +1,62 @@
-import os
-import os.path as osp
-import shutil
-import glob
-import numpy as np
-
-import torch_geometric.transforms as T
+# import os.path as osp
+# import torch_geometric.transforms as T
 from torch_geometric.datasets import ModelNet
-from ..data import Data, Dataset, download_url
 from . import register_dataset
 
 
 class ModelNet10(ModelNet):
-    def __init__(self, train, path):
-        dataset = "ModelNet10"
+    def __init__(self, path: str, train: bool):
         # pre_transform, transform = T.NormalizeScale(), T.SamplePoints(1024)
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
-        if not osp.exists(path):
-            ModelNet(path, "10")
         super(ModelNet10, self).__init__(path, name="10", train=train)
 
 
 class ModelNet40(ModelNet):
-    def __init__(self, train, path):
-        dataset = "ModelNet40"
+    def __init__(self, path: str, train: bool):
         # pre_transform, transform = T.NormalizeScale(), T.SamplePoints(1024)
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
-        if not osp.exists(path):
-            ModelNet(path, "40")
         super(ModelNet40, self).__init__(path, name="40", train=train)
 
 
-@register_dataset("ModelNet10")
-class ModelNetData10(ModelNet):
-    def __init__(self, path):
-        dataset = "ModelNet10"
-        # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
-        self.train_data = ModelNet10(True)
-        self.test_data = ModelNet10(False)
-        self.num_graphs = len(self.train_data) + len(self.test_data)
+@register_dataset("ModelNet10Train")
+class ModelNet10Train(ModelNet):
+    def __init__(self, path: str):
+        super(ModelNet10Train, self).__init__(path, '10', train=True)
 
-        super(ModelNetData10, self).__init__(path, name="10")
-
-    def get_all(self):
-        return self.train_data, self.test_data
-
-    def __getitem__(self, item):
-        if item < len(self.train_data):
-            return self.train_data[item]
-        return self.test_data[item]
-
-    def __len__(self):
-        return len(self.train_data) + len(self.test_data)
-
-    @property
-    def train_index(self):
-        return 0, len(self.train_data)
-
-    @property
-    def test_index(self):
-        return len(self.train_data), self.num_graphs
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(ModelNet10Train, self).get(idx)
 
 
-@register_dataset("ModelNet40")
-class ModelNetData40(ModelNet):
-    def __init__(self, path):
-        dataset = "ModelNet40"
-        # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
-        self.train_data = ModelNet40(True)
-        self.test_data = ModelNet40(False)
-        self.num_graphs = len(self.train_data) + len(self.test_data)
+@register_dataset("ModelNet10Test")
+class ModelNet10Test(ModelNet):
+    def __init__(self, path: str):
+        super(ModelNet10Test, self).__init__(path, '10', train=False)
 
-        super(ModelNetData40, self).__init__(path, name="40")
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(ModelNet10Test, self).get(idx)
 
-    def get_all(self):
-        return self.train_data, self.test_data
 
-    def __getitem__(self, item):
-        if item < len(self.train_data):
-            return self.train_data[item]
-        return self.test_data[item]
+@register_dataset("ModelNet40Train")
+class ModelNet40Train(ModelNet):
+    def __init__(self, path: str):
+        super(ModelNet40Train, self).__init__(path, '40', train=True)
 
-    def __len__(self):
-        return len(self.train_data) + len(self.test_data)
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(ModelNet40Train, self).get(idx)
 
-    @property
-    def train_index(self):
-        return 0, len(self.train_data)
 
-    @property
-    def test_index(self):
-        return len(self.train_data), self.num_graphs
+@register_dataset("ModelNet40Test")
+class ModelNet40Test(ModelNet):
+    def __init__(self, path: str):
+        super(ModelNet40Test, self).__init__(path, '40', train=False)
+
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(ModelNet40Test, self).get(idx)

--- a/autogl/datasets/ogb.py
+++ b/autogl/datasets/ogb.py
@@ -5,6 +5,8 @@ from ogb.linkproppred import PygLinkPropPredDataset
 from . import register_dataset
 from .utils import index_to_mask
 from torch_geometric.data import Data
+
+
 # OGBN
 
 
@@ -14,16 +16,14 @@ class OGBNproductsDataset(PygNodePropPredDataset):
         dataset = "ogbn-products"
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         PygNodePropPredDataset(name=dataset, root=path)
-        super(OGBNproductsDataset, self).__init__(
-            dataset, path
-        )
+        super(OGBNproductsDataset, self).__init__(dataset, path)
         # Pre-compute GCN normalization.
-        #adj_t = self.data.adj_t.set_diag()
-        #deg = adj_t.sum(dim=1).to(torch.float)
-        #deg_inv_sqrt = deg.pow(-0.5)
-        #deg_inv_sqrt[deg_inv_sqrt == float('inf')] = 0
-        #adj_t = deg_inv_sqrt.view(-1, 1) * adj_t * deg_inv_sqrt.view(1, -1)
-        #self.data.adj_t = adj_t
+        # adj_t = self.data.adj_t.set_diag()
+        # deg = adj_t.sum(dim=1).to(torch.float)
+        # deg_inv_sqrt = deg.pow(-0.5)
+        # deg_inv_sqrt[deg_inv_sqrt == float('inf')] = 0
+        # adj_t = deg_inv_sqrt.view(-1, 1) * adj_t * deg_inv_sqrt.view(1, -1)
+        # self.data.adj_t = adj_t
 
         setattr(OGBNproductsDataset, "metric", "Accuracy")
         setattr(OGBNproductsDataset, "loss", "nll_loss")
@@ -35,6 +35,12 @@ class OGBNproductsDataset(PygNodePropPredDataset):
             setattr(d, "test_mask", index_to_mask(split_idx['test'], d.y.shape[0]))
             datalist.append(d)
         self.data, self.slices = self.collate(datalist)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBNproductsDataset, self).get(idx)
+
 
 @register_dataset("ogbn-proteins")
 class OGBNproteinsDataset(PygNodePropPredDataset):
@@ -42,14 +48,12 @@ class OGBNproteinsDataset(PygNodePropPredDataset):
         dataset = "ogbn-proteins"
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         PygNodePropPredDataset(name=dataset, root=path)
-        super(OGBNproteinsDataset, self).__init__(
-            dataset, path
-        )
-        dataset_t = PygNodePropPredDataset(name=dataset, root = path, transform=T.ToSparseTensor())
+        super(OGBNproteinsDataset, self).__init__(dataset, path)
+        dataset_t = PygNodePropPredDataset(name=dataset, root=path, transform=T.ToSparseTensor())
 
         # Move edge features to node features.
         self.data.x = dataset_t[0].adj_t.mean(dim=1)
-        #dataset_t[0].adj_t.set_value_(None)
+        # dataset_t[0].adj_t.set_value_(None)
         del dataset_t
 
         setattr(OGBNproteinsDataset, "metric", "ROC-AUC")
@@ -62,6 +66,11 @@ class OGBNproteinsDataset(PygNodePropPredDataset):
             setattr(d, "test_mask", index_to_mask(split_idx['test'], d.y.shape[0]))
             datalist.append(d)
         self.data, self.slices = self.collate(datalist)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBNproteinsDataset, self).get(idx)
 
 
 @register_dataset("ogbn-arxiv")
@@ -70,12 +79,7 @@ class OGBNarxivDataset(PygNodePropPredDataset):
         dataset = "ogbn-arxiv"
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         PygNodePropPredDataset(name=dataset, root=path)
-        super(OGBNarxivDataset, self).__init__(
-            dataset, path
-        )
-
-        #self[0].adj_t = self[0].adj_t.to_symmetric()
-
+        super(OGBNarxivDataset, self).__init__(dataset, path)
         setattr(OGBNarxivDataset, "metric", "Accuracy")
         setattr(OGBNarxivDataset, "loss", "nll_loss")
         split_idx = self.get_idx_split()
@@ -87,6 +91,12 @@ class OGBNarxivDataset(PygNodePropPredDataset):
             setattr(d, "test_mask", index_to_mask(split_idx['test'], d.y.shape[0]))
             datalist.append(d)
         self.data, self.slices = self.collate(datalist)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBNarxivDataset, self).get(idx)
+
 
 @register_dataset("ogbn-papers100M")
 class OGBNpapers100MDataset(PygNodePropPredDataset):
@@ -94,9 +104,7 @@ class OGBNpapers100MDataset(PygNodePropPredDataset):
         dataset = "ogbn-papers100M"
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         PygNodePropPredDataset(name=dataset, root=path)
-        super(OGBNpapers100MDataset, self).__init__(
-            dataset, path
-        )
+        super(OGBNpapers100MDataset, self).__init__(dataset, path)
         setattr(OGBNpapers100MDataset, "metric", "Accuracy")
         setattr(OGBNpapers100MDataset, "loss", "nll_loss")
         split_idx = self.get_idx_split()
@@ -107,6 +115,12 @@ class OGBNpapers100MDataset(PygNodePropPredDataset):
             setattr(d, "test_mask", index_to_mask(split_idx['test'], d.y.shape[0]))
             datalist.append(d)
         self.data, self.slices = self.collate(datalist)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBNpapers100MDataset, self).get(idx)
+
 
 @register_dataset("ogbn-mag")
 class OGBNmagDataset(PygNodePropPredDataset):
@@ -114,11 +128,9 @@ class OGBNmagDataset(PygNodePropPredDataset):
         dataset = "ogbn-mag"
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         PygNodePropPredDataset(name=dataset, root=path)
-        super(OGBNmagDataset, self).__init__(
-            dataset, path
-        )
+        super(OGBNmagDataset, self).__init__(dataset, path)
 
-        # Preprocessing
+        # Preprocess
         rel_data = self[0]
         # We are only interested in paper <-> paper relations.
         self.data = Data(
@@ -126,8 +138,8 @@ class OGBNmagDataset(PygNodePropPredDataset):
             edge_index=rel_data.edge_index_dict[('paper', 'cites', 'paper')],
             y=rel_data.y_dict['paper'])
 
-        #self.data = T.ToSparseTensor()(data)
-        #self[0].adj_t = self[0].adj_t.to_symmetric()
+        # self.data = T.ToSparseTensor()(data)
+        # self[0].adj_t = self[0].adj_t.to_symmetric()
 
         setattr(OGBNmagDataset, "metric", "Accuracy")
         setattr(OGBNmagDataset, "loss", "nll_loss")
@@ -140,6 +152,11 @@ class OGBNmagDataset(PygNodePropPredDataset):
             setattr(d, "test_mask", index_to_mask(split_idx['test'], d.y.shape[0]))
             datalist.append(d)
         self.data, self.slices = self.collate(datalist)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBNmagDataset, self).get(idx)
 
 
 # OGBG
@@ -154,6 +171,11 @@ class OGBGmolhivDataset(PygGraphPropPredDataset):
         super(OGBGmolhivDataset, self).__init__(dataset, path)
         setattr(OGBGmolhivDataset, "metric", "ROC-AUC")
         setattr(OGBGmolhivDataset, "loss", "binary_cross_entropy_with_logits")
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBGmolhivDataset, self).get(idx)
 
 
 @register_dataset("ogbg-molpcba")
@@ -165,6 +187,11 @@ class OGBGmolpcbaDataset(PygGraphPropPredDataset):
         super(OGBGmolpcbaDataset, self).__init__(dataset, path)
         setattr(OGBGmolpcbaDataset, "metric", "AP")
         setattr(OGBGmolpcbaDataset, "loss", "binary_cross_entropy_with_logits")
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBGmolpcbaDataset, self).get(idx)
 
 
 @register_dataset("ogbg-ppa")
@@ -176,6 +203,11 @@ class OGBGppaDataset(PygGraphPropPredDataset):
         super(OGBGppaDataset, self).__init__(dataset, path)
         setattr(OGBGppaDataset, "metric", "Accuracy")
         setattr(OGBGppaDataset, "loss", "cross_entropy")
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBGppaDataset, self).get(idx)
 
 
 @register_dataset("ogbg-code")
@@ -187,6 +219,11 @@ class OGBGcodeDataset(PygGraphPropPredDataset):
         super(OGBGcodeDataset, self).__init__(dataset, path)
         setattr(OGBGcodeDataset, "metric", "F1 score")
         setattr(OGBGcodeDataset, "loss", "cross_entropy")
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBGcodeDataset, self).get(idx)
 
 
 # OGBL
@@ -201,6 +238,11 @@ class OGBLppaDataset(PygLinkPropPredDataset):
         super(OGBLppaDataset, self).__init__(dataset, path)
         setattr(OGBLppaDataset, "metric", "Hits@100")
         setattr(OGBLppaDataset, "loss", "pos_neg_loss")
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBLppaDataset, self).get(idx)
 
 
 @register_dataset("ogbl-collab")
@@ -212,6 +254,11 @@ class OGBLcollabDataset(PygLinkPropPredDataset):
         super(OGBLcollabDataset, self).__init__(dataset, path)
         setattr(OGBLcollabDataset, "metric", "Hits@50")
         setattr(OGBLcollabDataset, "loss", "pos_neg_loss")
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBLcollabDataset, self).get(idx)
 
 
 @register_dataset("ogbl-ddi")
@@ -223,6 +270,11 @@ class OGBLddiDataset(PygLinkPropPredDataset):
         super(OGBLddiDataset, self).__init__(dataset, path)
         setattr(OGBLddiDataset, "metric", "Hits@20")
         setattr(OGBLddiDataset, "loss", "pos_neg_loss")
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBLddiDataset, self).get(idx)
 
 
 @register_dataset("ogbl-citation")
@@ -234,6 +286,11 @@ class OGBLcitationDataset(PygLinkPropPredDataset):
         super(OGBLcitationDataset, self).__init__(dataset, path)
         setattr(OGBLcitationDataset, "metric", "MRR")
         setattr(OGBLcitationDataset, "loss", "pos_neg_loss")
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBLcitationDataset, self).get(idx)
 
 
 @register_dataset("ogbl-wikikg")
@@ -245,6 +302,11 @@ class OGBLwikikgDataset(PygLinkPropPredDataset):
         super(OGBLwikikgDataset, self).__init__(dataset, path)
         setattr(OGBLwikikgDataset, "metric", "MRR")
         setattr(OGBLwikikgDataset, "loss", "pos_neg_loss")
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBLwikikgDataset, self).get(idx)
 
 
 @register_dataset("ogbl-biokg")
@@ -256,3 +318,8 @@ class OGBLbiokgDataset(PygLinkPropPredDataset):
         super(OGBLbiokgDataset, self).__init__(dataset, path)
         setattr(OGBLbiokgDataset, "metric", "MRR")
         setattr(OGBLbiokgDataset, "loss", "pos_neg_loss")
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(OGBLbiokgDataset, self).get(idx)

--- a/autogl/datasets/pyg.py
+++ b/autogl/datasets/pyg.py
@@ -1,14 +1,12 @@
 import os.path as osp
 
 import torch
-
-import torch_geometric.transforms as T
+# import torch_geometric.transforms as T
 from torch_geometric.datasets import (
     Planetoid,
     Reddit,
     TUDataset,
     QM9,
-    ModelNet,
     Amazon,
     Coauthor,
 )
@@ -23,6 +21,11 @@ class AmazonComputersDataset(Amazon):
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         Amazon(path, dataset)
         super(AmazonComputersDataset, self).__init__(path, dataset)
+        
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(AmazonComputersDataset, self).get(idx)
 
 
 @register_dataset("amazon_photo")
@@ -32,6 +35,11 @@ class AmazonPhotoDataset(Amazon):
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         Amazon(path, dataset)
         super(AmazonPhotoDataset, self).__init__(path, dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(AmazonPhotoDataset, self).get(idx)
 
 
 @register_dataset("coauthor_physics")
@@ -41,6 +49,11 @@ class CoauthorPhysicsDataset(Coauthor):
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         Coauthor(path, dataset)
         super(CoauthorPhysicsDataset, self).__init__(path, dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(CoauthorPhysicsDataset, self).get(idx)
 
 
 @register_dataset("coauthor_cs")
@@ -50,6 +63,11 @@ class CoauthorCSDataset(Coauthor):
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         Coauthor(path, dataset)
         super(CoauthorCSDataset, self).__init__(path, dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(CoauthorCSDataset, self).get(idx)
 
 
 @register_dataset("cora")
@@ -59,6 +77,11 @@ class CoraDataset(Planetoid):
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         Planetoid(path, dataset)
         super(CoraDataset, self).__init__(path, dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(CoraDataset, self).get(idx)
 
 
 @register_dataset("citeseer")
@@ -68,6 +91,11 @@ class CiteSeerDataset(Planetoid):
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         Planetoid(path, dataset)
         super(CiteSeerDataset, self).__init__(path, dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(CiteSeerDataset, self).get(idx)
 
 
 @register_dataset("pubmed")
@@ -77,6 +105,11 @@ class PubMedDataset(Planetoid):
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         Planetoid(path, dataset)
         super(PubMedDataset, self).__init__(path, dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(PubMedDataset, self).get(idx)
 
 
 @register_dataset("reddit")
@@ -86,6 +119,11 @@ class RedditDataset(Reddit):
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         Reddit(path)
         super(RedditDataset, self).__init__(path)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(RedditDataset, self).get(idx)
 
 
 @register_dataset("mutag")
@@ -96,23 +134,38 @@ class MUTAGDataset(TUDataset):
         TUDataset(path, name=dataset)
         super(MUTAGDataset, self).__init__(path, name=dataset)
 
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(MUTAGDataset, self).get(idx)
+
 
 @register_dataset("imdb-b")
-class ImdbBinaryDataset(TUDataset):
+class IMDBBinaryDataset(TUDataset):
     def __init__(self, path):
         dataset = "IMDB-BINARY"
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         TUDataset(path, name=dataset)
-        super(ImdbBinaryDataset, self).__init__(path, name=dataset)
+        super(IMDBBinaryDataset, self).__init__(path, name=dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(IMDBBinaryDataset, self).get(idx)
 
 
 @register_dataset("imdb-m")
-class ImdbMultiDataset(TUDataset):
+class IMDBMultiDataset(TUDataset):
     def __init__(self, path):
         dataset = "IMDB-MULTI"
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         TUDataset(path, name=dataset)
-        super(ImdbMultiDataset, self).__init__(path, name=dataset)
+        super(IMDBMultiDataset, self).__init__(path, name=dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(IMDBMultiDataset, self).get(idx)
 
 
 @register_dataset("collab")
@@ -122,42 +175,67 @@ class CollabDataset(TUDataset):
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         TUDataset(path, name=dataset)
         super(CollabDataset, self).__init__(path, name=dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(CollabDataset, self).get(idx)
 
 
 @register_dataset("proteins")
-class ProtainsDataset(TUDataset):
+class ProteinsDataset(TUDataset):
     def __init__(self, path):
         dataset = "PROTEINS"
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         TUDataset(path, name=dataset)
-        super(ProtainsDataset, self).__init__(path, name=dataset)
+        super(ProteinsDataset, self).__init__(path, name=dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(ProteinsDataset, self).get(idx)
 
 
 @register_dataset("reddit-b")
-class RedditBinary(TUDataset):
+class REDDITBinary(TUDataset):
     def __init__(self, path):
         dataset = "REDDIT-BINARY"
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         TUDataset(path, name=dataset)
-        super(RedditBinary, self).__init__(path, name=dataset)
+        super(REDDITBinary, self).__init__(path, name=dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(REDDITBinary, self).get(idx)
 
 
 @register_dataset("reddit-multi-5k")
-class RedditMulti5K(TUDataset):
+class REDDITMulti5K(TUDataset):
     def __init__(self, path):
         dataset = "REDDIT-MULTI-5K"
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         TUDataset(path, name=dataset)
-        super(RedditMulti5K, self).__init__(path, name=dataset)
+        super(REDDITMulti5K, self).__init__(path, name=dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(REDDITMulti5K, self).get(idx)
 
 
 @register_dataset("reddit-multi-12k")
-class RedditMulti12K(TUDataset):
+class REDDITMulti12K(TUDataset):
     def __init__(self, path):
         dataset = "REDDIT-MULTI-12K"
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         TUDataset(path, name=dataset)
-        super(RedditMulti12K, self).__init__(path, name=dataset)
+        super(REDDITMulti12K, self).__init__(path, name=dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(REDDITMulti12K, self).get(idx)
 
 
 @register_dataset("ptc-mr")
@@ -168,23 +246,38 @@ class PTCMRDataset(TUDataset):
         TUDataset(path, name=dataset)
         super(PTCMRDataset, self).__init__(path, name=dataset)
 
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(PTCMRDataset, self).get(idx)
+
 
 @register_dataset("nci1")
-class NCT1Dataset(TUDataset):
+class NCI1Dataset(TUDataset):
     def __init__(self, path):
         dataset = "NCI1"
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         TUDataset(path, name=dataset)
-        super(NCT1Dataset, self).__init__(path, name=dataset)
+        super(NCI1Dataset, self).__init__(path, name=dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(NCI1Dataset, self).get(idx)
 
 
 @register_dataset("nci109")
-class NCT109Dataset(TUDataset):
+class NCI109Dataset(TUDataset):
     def __init__(self, path):
         dataset = "NCI109"
         # path = osp.join(osp.dirname(osp.realpath(__file__)), "../..", "data", dataset)
         TUDataset(path, name=dataset)
-        super(NCT109Dataset, self).__init__(path, name=dataset)
+        super(NCI109Dataset, self).__init__(path, name=dataset)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(NCI109Dataset, self).get(idx)
 
 
 @register_dataset("enzymes")
@@ -205,6 +298,11 @@ class ENZYMES(TUDataset):
             return data
         else:
             return self.index_select(idx)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(ENZYMES, self).get(idx)
 
 
 @register_dataset("qm9")
@@ -244,3 +342,8 @@ class QM9Dataset(QM9):
         if not osp.exists(path):
             QM9(path)
         super(QM9Dataset, self).__init__(path)
+    
+    def get(self, idx):
+        if hasattr(self, '__data_list__'):
+            delattr(self, '__data_list__')
+        return super(QM9Dataset, self).get(idx)


### PR DESCRIPTION
Temporarily override the get method for the datasets provided by PyTorch-Geometric to make the AutoGL compatible with PyTorch-Geometric>=1.6.2, aiming to fix the issue #10 .
For version 1.6.2 or higher, the PyG InMemoryDataset has an additional internal attribute `__data_list__` by default. If an in-memory dataset has the attribute and it is not None, then the item in the given specific index will be directly returned without accessing the data property.
The details can be found in https://github.com/rusty1s/pytorch_geometric/blob/master/torch_geometric/data/in_memory_dataset.py.

Besides, the PyG matainer *rusty1s* also mentioned that "accessing dataset.data is not recommended" in https://github.com/rusty1s/pytorch_geometric/issues/1984. In other words, mutating the data property of InMemoryDataset is not recommended by the PyTorch-Geometric.
However, the current version of AutoGL does modify the data property of dataset. Thus the get method of the PyG provided datasets is overrided to delete the `__data_list__` attribute in advance before calling the virtual get method, aiming to temporarily fix the compatibility issue.

In addition, the ModelNet10 and ModelNet40 datasets are significantly modified.