### PR TITLE
Refactor to decouple common models

### DIFF
--- a/autogl/module/model/dgl/_decoder/__init__.py
+++ b/autogl/module/model/dgl/_decoder/__init__.py
@@ -1,0 +1,12 @@
+from ._decoder import RepresentationDecoder
+from ._decoder_registry import RepresentationDecoderUniversalRegistry
+from ._decoders import LogSoftmaxDecoder, GINDecoder, TopKPoolDecoder
+
+
+__all__ = [
+    'RepresentationDecoder',
+    'RepresentationDecoderUniversalRegistry',
+    'LogSoftmaxDecoder',
+    'GINDecoder',
+    'TopKPoolDecoder'
+]

--- a/autogl/module/model/dgl/_decoder/_decoder.py
+++ b/autogl/module/model/dgl/_decoder/_decoder.py
@@ -1,0 +1,73 @@
+import dgl
+import torch
+import typing as _typing
+
+
+class _DecoderDefaultCompatibleTasks(_typing.Container[str], _typing.Iterable[str]):
+    """ Default compatible tasks for specific representation decoder """
+    def __init__(
+            self,
+            node_classification_compatible: bool,
+            graph_classification_compatible: bool,
+            link_prediction_compatible: bool
+    ):
+        self.__node_classification_compatible: bool = node_classification_compatible
+        self.__graph_classification_compatible: bool = graph_classification_compatible
+        self.__link_prediction_compatible: bool = link_prediction_compatible
+
+    @property
+    def compatible_tasks(self) -> _typing.Sequence[str]:
+        compatible_tasks: _typing.MutableSequence[str] = []
+        if self.node_classification_compatible:
+            compatible_tasks.append("node_classification")
+        if self.graph_classification_compatible:
+            compatible_tasks.append("graph_classification")
+        if self.link_prediction_compatible:
+            compatible_tasks.append("link_prediction")
+        return tuple(compatible_tasks)
+
+    def __contains__(self, task_identifier: object):
+        return (
+            task_identifier.lower() in self.compatible_tasks
+            if isinstance(task_identifier, str) else False
+        )
+
+    def __iter__(self) -> _typing.Iterator[str]:
+        return iter(self.compatible_tasks)
+
+    @property
+    def node_classification_compatible(self) -> bool:
+        return self.__node_classification_compatible
+
+    @property
+    def graph_classification_compatible(self) -> bool:
+        return self.__graph_classification_compatible
+
+    @property
+    def link_prediction_compatible(self) -> bool:
+        return self.__link_prediction_compatible
+
+
+class RepresentationDecoder(torch.nn.Module):
+    def __init__(self, *args, **kwargs):
+        super(RepresentationDecoder, self).__init__()
+        self._args: _typing.Sequence[_typing.Any] = args
+        self._kwargs: _typing.Mapping[str, _typing.Any] = kwargs
+        self.__default_compatible_tasks: _DecoderDefaultCompatibleTasks = (
+            _DecoderDefaultCompatibleTasks(
+                bool(kwargs.get("node_classification_compatible", False)),
+                bool(kwargs.get("graph_classification_compatible", False)),
+                bool(kwargs.get("link_classification_compatible", False))
+            )
+        )
+
+    @property
+    def default_compatible_tasks(self) -> _DecoderDefaultCompatibleTasks:
+        return self.__default_compatible_tasks
+
+    def __call__(
+            self, graph: dgl.DGLGraph,
+            features: _typing.Union[torch.Tensor, _typing.Sequence[torch.Tensor]],
+            *args, **kwargs
+    ) -> torch.Tensor:
+        raise NotImplementedError

--- a/autogl/module/model/dgl/_decoder/_decoder_registry.py
+++ b/autogl/module/model/dgl/_decoder/_decoder_registry.py
@@ -1,0 +1,59 @@
+import typing as _typing
+from . import _decoder
+
+
+class _RepresentationDecoderUniversalRegistryMetaclass(type):
+    def __new__(
+            mcs, name: str, bases: _typing.Tuple[type, ...],
+            namespace: _typing.Dict[str, _typing.Any]
+    ):
+        return super(_RepresentationDecoderUniversalRegistryMetaclass, mcs).__new__(
+            mcs, name, bases, namespace
+        )
+
+    def __init__(
+            cls, name: str, bases: _typing.Tuple[type, ...],
+            namespace: _typing.Dict[str, _typing.Any]
+    ):
+        super(_RepresentationDecoderUniversalRegistryMetaclass, cls).__init__(
+            name, bases, namespace
+        )
+        cls._representation_decoder_registry: _typing.MutableMapping[
+            str, _typing.Type[_decoder.RepresentationDecoder]
+        ] = {}
+
+
+class RepresentationDecoderUniversalRegistry(
+    metaclass=_RepresentationDecoderUniversalRegistryMetaclass
+):
+    @classmethod
+    def register_representation_decoder(cls, name: str) -> _typing.Callable[
+        [_typing.Type[_decoder.RepresentationDecoder]],
+        _typing.Type[_decoder.RepresentationDecoder]
+    ]:
+        def register_decoder(
+                decoder: _typing.Type[_decoder.RepresentationDecoder]
+        ) -> _typing.Type[_decoder.RepresentationDecoder]:
+            if name in cls._representation_decoder_registry:
+                raise ValueError(
+                    f"Representation Decoder with name \"{name}\" already exists!"
+                )
+            elif not issubclass(decoder, _decoder.RepresentationDecoder):
+                raise TypeError
+            else:
+                cls._representation_decoder_registry[name] = decoder
+                return decoder
+
+        return register_decoder
+
+    @classmethod
+    def get_representation_decoder(cls, name: str) -> (
+            _typing.Type[_decoder.RepresentationDecoder]
+    ):
+        decoder: _typing.Optional[
+            _typing.Type[_decoder.RepresentationDecoder]
+        ] = cls._representation_decoder_registry.get(name)
+        if decoder is not None and issubclass(decoder, _decoder.RepresentationDecoder):
+            return decoder
+        else:
+            raise ValueError(f"representation decoder with name \"{name}\" not found")

--- a/autogl/module/model/dgl/_decoder/_decoders.py
+++ b/autogl/module/model/dgl/_decoder/_decoders.py
@@ -1,0 +1,193 @@
+import dgl
+from dgl.nn.pytorch.glob import (
+    AvgPooling, MaxPooling, SortPooling, SumPooling
+)
+import torch.nn.functional
+import typing as _typing
+from . import _decoder
+from ._decoder_registry import RepresentationDecoderUniversalRegistry
+
+
+def activate_func(x, func):
+    if func == "tanh":
+        return torch.tanh(x)
+    elif hasattr(torch.nn.functional, func):
+        return getattr(torch.nn.functional, func)(x)
+    elif func == "":
+        pass
+    else:
+        raise TypeError("PyTorch does not support activation function {}".format(func))
+    return x
+
+
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("log_softmax")
+class LogSoftmaxDecoder(_decoder.RepresentationDecoder):
+    def __call__(
+            self, graph: dgl.DGLGraph,
+            features: _typing.Union[torch.Tensor, _typing.Sequence[torch.Tensor]],
+            *args, **kwargs
+    ) -> torch.Tensor:
+        if isinstance(features, torch.Tensor) and torch.is_tensor(features):
+            return torch.nn.functional.log_softmax(features, dim=-1)
+        elif isinstance(features, _typing.Sequence):
+            if len(features) == 0:
+                raise ValueError
+            if not (
+                    isinstance(features[0], torch.Tensor)
+                    and torch.is_tensor(features[0])
+            ):
+                raise TypeError
+            return torch.nn.functional.log_softmax(features[0], dim=-1)
+        else:
+            raise TypeError
+
+
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("gin")
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("gin_decoder")
+class GINDecoder(_decoder.RepresentationDecoder):
+    def __init__(self, hyper_parameters: _typing.Mapping[str, _typing.Any], *args, **kwargs):
+        super(GINDecoder, self).__init__(hyper_parameters, *args, **kwargs)
+        num_layers: int = hyper_parameters["num_layers"]
+
+        temp: _typing.Tuple[_typing.Optional[int], _typing.Optional[int]] = (
+            hyper_parameters.get("num_classes"), hyper_parameters.get("num_class")
+        )
+        if all([(not isinstance(i, int)) for i in temp]):
+            raise ValueError("num_classes or num_class not exists")
+        else:
+            num_classes: int = temp[0] if isinstance(temp[0], int) else temp[1]
+            if not num_classes > 0:
+                raise ValueError("num_classes must be positive integer")
+
+        num_graph_features: int = hyper_parameters["num_graph_features"]
+        graph_pooling_type: str = hyper_parameters["graph_pooling_type"]
+        hidden: _typing.Sequence[int] = hyper_parameters["hidden"]
+        self.__activation: str = hyper_parameters["act"]
+        self.__dropout: float = hyper_parameters["dropout"]
+        self.__fc1: torch.nn.Linear = torch.nn.Linear(
+            hidden[num_layers - 3] + num_graph_features,
+            hidden[num_layers - 3]
+        )
+        self.__fc2: torch.nn.Linear = torch.nn.Linear(
+            hidden[num_layers - 2], num_classes
+        )
+        if graph_pooling_type == 'sum':
+            self.__pool = SumPooling()
+        elif graph_pooling_type == 'mean':
+            self.__pool = AvgPooling()
+        elif graph_pooling_type == 'max':
+            self.__pool = MaxPooling()
+        else:
+            raise ValueError
+
+    def __call__(
+            self, graph: dgl.DGLGraph,
+            features: _typing.Union[torch.Tensor, _typing.Sequence[torch.Tensor]],
+            *args, **kwargs
+    ) -> torch.Tensor:
+        if isinstance(features, torch.Tensor) and torch.is_tensor(features):
+            feature: torch.Tensor = features
+        elif isinstance(features, _typing.Sequence):
+            if len(features) == 0:
+                raise ValueError
+            if not (
+                isinstance(features[0], torch.Tensor)
+                and torch.is_tensor(features[0])
+            ):
+                raise TypeError
+            else:
+                feature: torch.Tensor = features[0]
+        else:
+            raise TypeError
+        feature: torch.Tensor = self.__fc1(feature)
+        feature: torch.Tensor = activate_func(feature, self.__activation)
+        feature: torch.Tensor = torch.nn.functional.dropout(
+            feature, self.__dropout, training=self.training
+        )
+        feature: torch.Tensor = self.__fc2(feature)
+        feature: torch.Tensor = self.__pool.forward(graph, feature)
+        return torch.nn.functional.log_softmax(feature, dim=1)
+
+
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("TopK".lower())
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("TopKPool".lower())
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("TopK_decoder".lower())
+class TopKPoolDecoder(_decoder.RepresentationDecoder):
+    def __init__(self, hyper_parameters: _typing.Mapping[str, _typing.Any], *args, **kwargs):
+        super(TopKPoolDecoder, self).__init__(hyper_parameters, *args, **kwargs)
+
+        temp: _typing.Tuple[_typing.Optional[int], _typing.Optional[int]] = (
+            hyper_parameters.get("num_features"), hyper_parameters.get("features_num")
+        )
+        if all([(not isinstance(i, int)) for i in temp]):
+            raise ValueError("num_features or features_num not exists")
+        else:
+            num_features: int = temp[0] if isinstance(temp[0], int) else temp[1]
+            if not num_features > 0:
+                raise ValueError("Illegal number of features")
+        temp: _typing.Tuple[_typing.Optional[int], _typing.Optional[int]] = (
+            hyper_parameters.get("num_classes"), hyper_parameters.get("num_class")
+        )
+        if all([(not isinstance(i, int)) for i in temp]):
+            raise ValueError("num_classes or num_class not exists")
+        else:
+            num_classes: int = temp[0] if isinstance(temp[0], int) else temp[1]
+            if not num_classes > 0:
+                raise ValueError("num_classes must be positive integer")
+
+        num_layers: int = hyper_parameters["num_layers"]
+        hidden_dimension: int = hyper_parameters["hidden"][0]
+        dropout: float = hyper_parameters.get("dropout", 0)
+        k: int = hyper_parameters.get("k", 3)
+
+        self.__num_layers: int = num_layers
+        self.__pool = SortPooling(k)
+        self.__linear_layers: torch.nn.ModuleList = torch.nn.ModuleList()
+        for layer in range(num_layers):
+            self.__linear_layers.append(
+                torch.nn.Linear(num_features * k, num_classes) if layer == 0
+                else torch.nn.Linear(hidden_dimension * k, num_classes)
+            )
+        self.__dropout: torch.nn.Dropout = torch.nn.Dropout(dropout)
+
+    def __call__(
+            self, graph: dgl.DGLGraph,
+            features: _typing.Union[torch.Tensor, _typing.Sequence[torch.Tensor]],
+            *args, **kwargs
+    ) -> torch.Tensor:
+        if not isinstance(features, _typing.Sequence):
+            raise TypeError
+        if not len(features) == self.__num_layers:
+            raise ValueError
+        if not all([torch.is_tensor(feature) for feature in features]):
+            raise TypeError
+
+        score_over_layer = torch.zeros(1)
+        for i, feature in enumerate(features):
+            pooled_h = self.__pool(graph, feature)
+            score_over_layer += self.__dropout(self.__linear_layers[i](pooled_h))
+
+        return score_over_layer
+
+
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("lp_decoder")
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("LinkPrediction_decoder".lower())
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("Link_Prediction_decoder".lower())
+class LinkPredictionDecoder(_decoder.RepresentationDecoder):
+    def __call__(self, graph: dgl.DGLGraph, features: _typing.Union[torch.Tensor, _typing.Sequence[torch.Tensor]], *args, **kwargs) -> torch.Tensor:
+        z: torch.Tensor = graph.ndata['feat']
+        if (
+                "pos_edge_index" in kwargs and "neg_edge_index" in kwargs and
+                isinstance(kwargs["pos_edge_index"], torch.Tensor) and
+                isinstance(kwargs["neg_edge_index"], torch.Tensor) and
+                torch.is_tensor(kwargs["pos_edge_index"]) and
+                torch.is_tensor(kwargs["neg_edge_index"])
+        ):
+            pos_edge_index: torch.Tensor = kwargs["pos_edge_index"]
+            neg_edge_index: torch.Tensor = kwargs["neg_edge_index"]
+        else:
+            raise ValueError
+
+        edge_index = torch.cat([pos_edge_index, neg_edge_index], dim=-1)
+        logits = (z[edge_index[0]] * z[edge_index[1]]).sum(dim=-1)
+        return logits

--- a/autogl/module/model/dgl/base.py
+++ b/autogl/module/model/dgl/base.py
@@ -64,6 +64,7 @@ class BaseModel:
             num_classes=self.num_classes,
             device=self.device,
             init=False,
+            decoder=getattr(self, "decoder")
         )
         ret_self.hyperparams.update(hp)
         ret_self.params.update(self.params)

--- a/autogl/module/model/dgl/gat.py
+++ b/autogl/module/model/dgl/gat.py
@@ -1,10 +1,9 @@
 import torch
-import torch.nn.functional as F
+import typing as _typing
 from dgl.nn.pytorch.conv import GATConv
-from . import register_model
+from . import _decoder, register_model
 from .base import BaseModel, activate_func
 from ....utils import get_logger
-import dgl
 
 LOGGER = get_logger("GATModel")
 
@@ -17,7 +16,7 @@ def set_default(args, d):
 
 
 class GAT(torch.nn.Module):
-    def __init__(self, args):
+    def __init__(self, args, **kwargs):
         super(GAT, self).__init__()
         self.args = args
         self.num_layer = int(self.args["num_layers"])
@@ -43,6 +42,20 @@ class GAT(torch.nn.Module):
             LOGGER.warn("Warning: layer size does not match the length of hidden units")
         self.convs = torch.nn.ModuleList()
 
+        num_output_heads: int = self.args.get("num_output_heads", 1)
+
+        ''' Set decoder '''
+        decoder: _typing.Union[str, _typing.Type[_decoder.RepresentationDecoder], None] = kwargs.get("decoder")
+        if issubclass(decoder, _decoder.RepresentationDecoder):
+            self._decoder: _typing.Optional[_decoder.RepresentationDecoder] = decoder(self.args)
+        elif isinstance(decoder, str) and len(decoder.strip()) > 0:
+            self._decoder: _typing.Optional[_decoder.RepresentationDecoder] = (
+                _decoder.RepresentationDecoderUniversalRegistry.get_representation_decoder(decoder)(
+                    self.args
+                ) if not ('no' in decoder.lower() or 'null' in decoder.lower()) else None
+            )
+        else:
+            self._decoder: _typing.Optional[_decoder.RepresentationDecoder] = None
         
         self.convs.append(
             GATConv(
@@ -69,13 +82,13 @@ class GAT(torch.nn.Module):
             GATConv(
                 last_dim,
                 self.args["num_class"],
-                num_heads=1,
+                num_heads=num_output_heads,
                 feat_drop=self.args.get("feat_drop", self.args["dropout"]),
                 attn_drop=self.args["dropout"],
             )
         )
 
-    def forward(self, data):
+    def forward(self, data, *args, **kwargs):
         try:
             x = data.ndata['feat']
         except:
@@ -89,9 +102,11 @@ class GAT(torch.nn.Module):
             x = self.convs[i](data, x).flatten(1)
             x = activate_func(x, self.args["act"])
 
-        x = self.convs[-1](data, x).mean(1)
-
-        return F.log_softmax(x, dim=1)
+        x = self.convs[-1](data, x).flattern(1)
+        if self._decoder is not None:
+            return self._decoder(data, x, *args, **kwargs)
+        else:
+            return x
 
     def lp_encode(self, data):
         x = data.ndata['feat']
@@ -153,13 +168,16 @@ class AutoGAT(BaseModel):
     """
 
     def __init__(
-        self, num_features=None, num_classes=None, device=None, init=False, **args
+            self, num_features=None, num_classes=None, device=None, init=False,
+            decoder: _typing.Union[_typing.Type[_decoder.RepresentationDecoder], str, None] = ...,
+            **kwargs
     ):
         super(AutoGAT, self).__init__()
         self.num_features = num_features if num_features is not None else 0
         self.num_classes = int(num_classes) if num_classes is not None else 0
         self.device = device if device is not None else "cpu"
         self.init = True
+        self.decoder = decoder
 
         self.params = {
             "features_num": self.num_features,
@@ -218,4 +236,4 @@ class AutoGAT(BaseModel):
         if self.initialized:
             return
         self.initialized = True
-        self.model = GAT({**self.params, **self.hyperparams}).to(self.device)
+        self.model = GAT({**self.params, **self.hyperparams}, decoder=self.decoder).to(self.device)

--- a/autogl/module/model/pyg/_decoder/__init__.py
+++ b/autogl/module/model/pyg/_decoder/__init__.py
@@ -1,0 +1,12 @@
+from ._decoder import RepresentationDecoder
+from ._decoder_registry import RepresentationDecoderUniversalRegistry
+from ._decoders import LogSoftmaxDecoder, GINDecoder, DiffPoolDecoder
+
+
+__all__ = [
+    'RepresentationDecoder',
+    'RepresentationDecoderUniversalRegistry',
+    'LogSoftmaxDecoder',
+    'GINDecoder',
+    'DiffPoolDecoder'
+]

--- a/autogl/module/model/pyg/_decoder/_decoder.py
+++ b/autogl/module/model/pyg/_decoder/_decoder.py
@@ -1,0 +1,69 @@
+import torch
+import torch_geometric
+import typing as _typing
+
+
+class _DecoderDefaultCompatibleTasks(_typing.Container[str], _typing.Iterable[str]):
+    """ Default compatible tasks for specific representation decoder """
+    def __init__(
+            self,
+            node_classification_compatible: bool,
+            graph_classification_compatible: bool,
+            link_prediction_compatible: bool
+    ):
+        self.__node_classification_compatible: bool = node_classification_compatible
+        self.__graph_classification_compatible: bool = graph_classification_compatible
+        self.__link_prediction_compatible: bool = link_prediction_compatible
+
+    @property
+    def compatible_tasks(self) -> _typing.Sequence[str]:
+        compatible_tasks: _typing.MutableSequence[str] = []
+        if self.node_classification_compatible:
+            compatible_tasks.append("node_classification")
+        if self.graph_classification_compatible:
+            compatible_tasks.append("graph_classification")
+        if self.link_prediction_compatible:
+            compatible_tasks.append("link_prediction")
+        return tuple(compatible_tasks)
+
+    def __contains__(self, task_identifier: object):
+        return (
+                task_identifier.lower() in self.compatible_tasks
+                if isinstance(task_identifier, str) else False
+        )
+
+    def __iter__(self) -> _typing.Iterator[str]:
+        return iter(self.compatible_tasks)
+
+    @property
+    def node_classification_compatible(self) -> bool:
+        return self.__node_classification_compatible
+
+    @property
+    def graph_classification_compatible(self) -> bool:
+        return self.__graph_classification_compatible
+
+    @property
+    def link_prediction_compatible(self) -> bool:
+        return self.__link_prediction_compatible
+
+
+class RepresentationDecoder(torch.nn.Module):
+    def __init__(self, *args, **kwargs):
+        super(RepresentationDecoder, self).__init__()
+        self._args: _typing.Sequence[_typing.Any] = args
+        self._kwargs: _typing.Mapping[str, _typing.Any] = kwargs
+        self.__default_compatible_tasks: _DecoderDefaultCompatibleTasks = (
+            _DecoderDefaultCompatibleTasks(
+                bool(kwargs.get("node_classification_compatible", False)),
+                bool(kwargs.get("graph_classification_compatible", False)),
+                bool(kwargs.get("link_classification_compatible", False))
+            )
+        )
+
+    @property
+    def default_compatible_tasks(self) -> _DecoderDefaultCompatibleTasks:
+        return self.__default_compatible_tasks
+
+    def __call__(self, data: torch_geometric.data.Data, *args, **kwargs) -> torch.Tensor:
+        raise NotImplementedError

--- a/autogl/module/model/pyg/_decoder/_decoder_registry.py
+++ b/autogl/module/model/pyg/_decoder/_decoder_registry.py
@@ -1,0 +1,59 @@
+import typing as _typing
+from . import _decoder
+
+
+class _RepresentationDecoderUniversalRegistryMetaclass(type):
+    def __new__(
+            mcs, name: str, bases: _typing.Tuple[type, ...],
+            namespace: _typing.Dict[str, _typing.Any]
+    ):
+        return super(_RepresentationDecoderUniversalRegistryMetaclass, mcs).__new__(
+            mcs, name, bases, namespace
+        )
+
+    def __init__(
+            cls, name: str, bases: _typing.Tuple[type, ...],
+            namespace: _typing.Dict[str, _typing.Any]
+    ):
+        super(_RepresentationDecoderUniversalRegistryMetaclass, cls).__init__(
+            name, bases, namespace
+        )
+        cls._representation_decoder_registry: _typing.MutableMapping[
+            str, _typing.Type[_decoder.RepresentationDecoder]
+        ] = {}
+
+
+class RepresentationDecoderUniversalRegistry(
+    metaclass=_RepresentationDecoderUniversalRegistryMetaclass
+):
+    @classmethod
+    def register_representation_decoder(cls, name: str) -> _typing.Callable[
+        [_typing.Type[_decoder.RepresentationDecoder]],
+        _typing.Type[_decoder.RepresentationDecoder]
+    ]:
+        def register_decoder(
+                decoder: _typing.Type[_decoder.RepresentationDecoder]
+        ) -> _typing.Type[_decoder.RepresentationDecoder]:
+            if name in cls._representation_decoder_registry:
+                raise ValueError(
+                    f"Representation Decoder with name \"{name}\" already exists!"
+                )
+            elif not issubclass(decoder, _decoder.RepresentationDecoder):
+                raise TypeError
+            else:
+                cls._representation_decoder_registry[name] = decoder
+                return decoder
+
+        return register_decoder
+
+    @classmethod
+    def get_representation_decoder(cls, name: str) -> (
+            _typing.Type[_decoder.RepresentationDecoder]
+    ):
+        decoder: _typing.Optional[
+            _typing.Type[_decoder.RepresentationDecoder]
+        ] = cls._representation_decoder_registry.get(name)
+        if decoder is not None and issubclass(decoder, _decoder.RepresentationDecoder):
+            return decoder
+        else:
+            raise ValueError(f"representation decoder with name \"{name}\" not found")

--- a/autogl/module/model/pyg/_decoder/_decoders.py
+++ b/autogl/module/model/pyg/_decoder/_decoders.py
@@ -1,0 +1,191 @@
+import torch.nn.functional
+import typing as _typing
+import torch_geometric
+from torch_geometric.nn.glob import global_mean_pool, global_max_pool
+from . import _decoder
+from ._decoder_registry import RepresentationDecoderUniversalRegistry
+
+
+def activate_func(x, func):
+    if func == "tanh":
+        return torch.tanh(x)
+    elif hasattr(torch.nn.functional, func):
+        return getattr(torch.nn.functional, func)(x)
+    elif func == "":
+        pass
+    else:
+        raise TypeError("PyTorch does not support activation function {}".format(func))
+    return x
+
+
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("log_softmax")
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("log_softmax_decoder")
+class LogSoftmaxDecoder(_decoder.RepresentationDecoder):
+    def __init__(self, hyper_parameters: _typing.Mapping[str, _typing.Any], *args, **kwargs):
+        kwargs["hyper_parameters"] = hyper_parameters
+        kwargs["node_classification_compatible"] = True
+        kwargs["graph_classification_compatible"] = False
+        kwargs["link_prediction_compatible"] = False
+        super(LogSoftmaxDecoder, self).__init__(args, kwargs)
+
+    def __call__(self, data: torch_geometric.data.Data, *args, **kwargs) -> torch.Tensor:
+        if (
+                hasattr(data, 'x') and
+                isinstance(getattr(data, 'x'), torch.Tensor) and
+                torch.is_tensor(getattr(data, 'x'))
+        ):
+            return torch.nn.functional.log_softmax(getattr(data, 'x'), dim=-1)
+        else:
+            raise TypeError
+
+
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("gin")
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("gin_decoder")
+class GINDecoder(_decoder.RepresentationDecoder):
+    def __init__(self, hyper_parameters: _typing.Mapping[str, _typing.Any], *args, **kwargs):
+        kwargs["hyper_parameters"] = hyper_parameters
+        kwargs["node_classification_compatible"] = False
+        kwargs["graph_classification_compatible"] = True
+        kwargs["link_prediction_compatible"] = False
+        super(GINDecoder, self).__init__(*args, **kwargs)
+        num_layers: int = hyper_parameters["num_layers"]
+
+        temp: _typing.Tuple[_typing.Optional[int], _typing.Optional[int]] = (
+            hyper_parameters.get("num_classes"), hyper_parameters.get("num_class")
+        )
+        if all([(not isinstance(i, int)) for i in temp]):
+            raise ValueError("num_classes or num_class not exists")
+        else:
+            num_classes: int = temp[0] if isinstance(temp[0], int) else temp[1]
+            if not num_classes > 0:
+                raise ValueError("num_classes must be positive integer")
+
+        num_graph_features: int = hyper_parameters["num_graph_features"]
+        self.__activation: str = hyper_parameters["act"]
+        self.__dropout: float = hyper_parameters.get("dropout", 0)
+
+        self.fc1 = torch.nn.Linear(
+            hyper_parameters["hidden"][num_layers - 3] + num_graph_features,
+            hyper_parameters["hidden"][num_layers - 2],
+            )
+        self.fc2 = torch.nn.Linear(
+            hyper_parameters["hidden"][num_layers - 2], num_classes
+        )
+
+    def __call__(self, data: torch_geometric.data.Data, *args, **kwargs) -> torch.Tensor:
+        if (
+                hasattr(data, 'x') and isinstance(getattr(data, 'x'), torch.Tensor) and
+                torch.is_tensor(getattr(data, 'x'))
+        ):
+            x: torch.Tensor = data.x
+        else:
+            raise TypeError
+        x = self.fc1(x)
+        x = activate_func(x, self.__activation)
+        x = torch.nn.functional.dropout(x, p=self.__dropout, training=self.training)
+        x = self.fc2(x)
+        return torch.nn.functional.log_softmax(x, dim=1)
+
+
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("DiffPool".lower())
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("DiffPool_decoder".lower())
+class DiffPoolDecoder(_decoder.RepresentationDecoder):
+    """
+    https://arxiv.org/abs/1905.05178
+    https://arxiv.org/abs/1905.02850
+    """
+    def __init__(self, hyper_parameters: _typing.Mapping[str, _typing.Any], *args, **kwargs):
+        kwargs["hyper_parameters"] = hyper_parameters
+        kwargs["node_classification_compatible"] = False
+        kwargs["graph_classification_compatible"] = True
+        kwargs["link_prediction_compatible"] = False
+        super(DiffPoolDecoder, self).__init__(*args, **kwargs)
+        temp: _typing.Tuple[_typing.Optional[int], _typing.Optional[int]] = (
+            hyper_parameters.get("num_classes"), hyper_parameters.get("num_class")
+        )
+        if all([(not isinstance(i, int)) for i in temp]):
+            raise ValueError("num_classes or num_class not exists")
+        else:
+            num_classes: int = temp[0] if isinstance(temp[0], int) else temp[1]
+            if not num_classes > 0:
+                raise ValueError("num_classes must be positive integer")
+        temp: _typing.Tuple[_typing.Optional[int], _typing.Optional[int]] = (
+            hyper_parameters.get("num_features"), hyper_parameters.get("features_num")
+        )
+        if all([(not isinstance(i, int)) for i in temp]):
+            raise ValueError("num_features or features_num not exists")
+        else:
+            num_features: int = temp[0] if isinstance(temp[0], int) else temp[1]
+            if not num_features > 0:
+                raise ValueError("num_features must be positive integer")
+        num_graph_features: int = hyper_parameters["num_graph_features"]
+        ratio: float = hyper_parameters["ratio"]
+        self.__activation: str = hyper_parameters["act"]
+        self.__dropout: float = hyper_parameters.get("dropout", 0)
+        self.conv1 = torch_geometric.nn.GraphConv(self.num_features, 128)
+        self.pool1 = torch_geometric.nn.TopKPooling(128, ratio=ratio)
+        self.conv2 = torch_geometric.nn.GraphConv(128, 128)
+        self.pool2 = torch_geometric.nn.TopKPooling(128, ratio=ratio)
+        self.conv3 = torch_geometric.nn.GraphConv(128, 128)
+        self.pool3 = torch_geometric.nn.TopKPooling(128, ratio=ratio)
+
+        self.lin1 = torch.nn.Linear(256 + num_graph_features, 128)
+        self.lin2 = torch.nn.Linear(128, 64)
+        self.lin3 = torch.nn.Linear(64, num_classes)
+
+    def __call__(self, data: torch_geometric.data.Data, *args, **kwargs) -> torch.Tensor:
+        x, edge_index, batch = data.x, data.edge_index, data.batch
+        if self.num_graph_features > 0:
+            graph_feature: _typing.Optional[torch.Tensor] = data.gf
+        else:
+            graph_feature = None
+
+        x = torch.nn.functional.relu(self.conv1(x, edge_index))
+        x, edge_index, _, batch, _, _ = self.pool1(x, edge_index, None, batch)
+        x1 = torch.cat([global_max_pool(x, batch), global_mean_pool(x, batch)], dim=1)
+
+        x = torch.nn.functional.relu(self.conv2(x, edge_index))
+        x, edge_index, _, batch, _, _ = self.pool2(x, edge_index, None, batch)
+        x2 = torch.cat([global_max_pool(x, batch), global_mean_pool(x, batch)], dim=1)
+
+        x = torch.nn.functional.relu(self.conv3(x, edge_index))
+        x, edge_index, _, batch, _, _ = self.pool3(x, edge_index, None, batch)
+        x3 = torch.cat([global_max_pool(x, batch), global_mean_pool(x, batch)], dim=1)
+
+        x = x1 + x2 + x3
+        if (
+                self.num_graph_features > 0 and
+                torch.is_tensor(graph_feature) and
+                isinstance(graph_feature, torch.Tensor)
+        ):
+            x = torch.cat([x, graph_feature], dim=-1)
+        x = self.lin1(x)
+        x = activate_func(x, self.__activation)
+        x = torch.nn.functional.dropout(x, p=self.__dropout, training=self.training)
+        x = self.lin2(x)
+        x = activate_func(x, self.__activation)
+        x = torch.nn.functional.log_softmax(self.lin3(x), dim=-1)
+        return x
+
+
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("lp_decoder")
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("LinkPrediction_decoder".lower())
+@RepresentationDecoderUniversalRegistry.register_representation_decoder("Link_Prediction_decoder".lower())
+class LinkPredictionDecoder(_decoder.RepresentationDecoder):
+    def __call__(self, data: torch_geometric.data.Data, *args, **kwargs) -> torch.Tensor:
+        z: torch.Tensor = data.x
+        if (
+                "pos_edge_index" in kwargs and "neg_edge_index" in kwargs and
+                isinstance(kwargs["pos_edge_index"], torch.Tensor) and
+                isinstance(kwargs["neg_edge_index"], torch.Tensor) and
+                torch.is_tensor(kwargs["pos_edge_index"]) and
+                torch.is_tensor(kwargs["neg_edge_index"])
+        ):
+            pos_edge_index: torch.Tensor = kwargs["pos_edge_index"]
+            neg_edge_index: torch.Tensor = kwargs["neg_edge_index"]
+        else:
+            raise ValueError
+
+        edge_index = torch.cat([pos_edge_index, neg_edge_index], dim=-1)
+        logits = (z[edge_index[0]] * z[edge_index[1]]).sum(dim=-1)
+        return logits

--- a/autogl/module/model/pyg/base.py
+++ b/autogl/module/model/pyg/base.py
@@ -64,6 +64,7 @@ class BaseModel:
             num_classes=self.num_classes,
             device=self.device,
             init=False,
+            decoder=getattr(self, "decoder")
         )
         ret_self.hyperparams.update(hp)
         ret_self.params.update(self.params)

--- a/autogl/module/model/pyg/topkpool.py
+++ b/autogl/module/model/pyg/topkpool.py
@@ -84,7 +84,8 @@ class Topkpool(torch.nn.Module):
         return x
 
 
-@register_model("topkpool")
+# DEPRECATED, This is not a integral model
+# @register_model("topkpool")
 class AutoTopkpool(BaseModel):
     r"""
     AutoTopkpool. The model used in this automodel is from https://arxiv.org/abs/1905.05178, https://arxiv.org/abs/1905.02850

--- a/autogl/module/train/link_prediction.py
+++ b/autogl/module/train/link_prediction.py
@@ -101,6 +101,9 @@ class LinkPredictionTrainer(BaseLinkPredictionTrainer):
         self.initialized = False
         self.device = device
 
+        if self.model is not None:
+            self.model.decoder = self.__get_model_decoder()
+
         self.space = [
             {
                 "parameterName": "max_epoch",
@@ -143,6 +146,12 @@ class LinkPredictionTrainer(BaseLinkPredictionTrainer):
 
         if init is True:
             self.initialize()
+
+    def __get_model_decoder(self) -> Union[str, None]:
+        if "model_decoder" in self.kwargs:
+            return self.kwargs["model_decoder"]
+        else:
+            return "lp_decoder"
 
     def initialize(self):
         #  Initialize the auto model in trainer.
@@ -484,6 +493,7 @@ class LinkPredictionTrainer(BaseLinkPredictionTrainer):
                 ]
             )
         )
+        model.decoder = self.__get_model_decoder()
 
         ret = self.__class__(
             model=model,

--- a/autogl/module/train/node_classification_full.py
+++ b/autogl/module/train/node_classification_full.py
@@ -118,6 +118,9 @@ class NodeClassificationFullTrainer(BaseNodeClassificationTrainer):
 
         self.pyg_dgl = DependentBackend.get_backend_name()
 
+        if self.model is not None:
+            self.model.decoder = self.__get_model_decoder()
+
         self.space = [
             {
                 "parameterName": "max_epoch",
@@ -158,6 +161,12 @@ class NodeClassificationFullTrainer(BaseNodeClassificationTrainer):
 
         if init is True:
             self.initialize()
+
+    def __get_model_decoder(self) -> Union[str, None]:
+        if "model_decoder" in self.kwargs:
+            return self.kwargs["model_decoder"]
+        else:
+            return "log_softmax"
 
     def initialize(self):
         #  Initialize the auto model in trainer.
@@ -514,6 +523,7 @@ class NodeClassificationFullTrainer(BaseNodeClassificationTrainer):
                 ]
             )
         )
+        model.decoder = self.__get_model_decoder()
 
         ret = self.__class__(
             model=model,


### PR DESCRIPTION
**Warning:** careful review is highly necessary for this Pull Request!!! As I am not very sure whether there exist any inappropriate design. @Frozenmad 
If there exists some any unproper design, please let me know to revise.
The base class `_DecoderDefaultCompatibleTasks` is temporately useless, for which the declarations are designed for (pending) advanced feature that specific model has specific default decoder, as is proposed by Chaoyu and Ziwei on Nov 19th.