### PR TITLE
Modify GIN encoder&decoder for DGL Backend

### DIFF
--- a/autogl/datasets/utils/_general.py
+++ b/autogl/datasets/utils/_general.py
@@ -295,7 +295,7 @@ def graph_random_splits(
 def graph_get_split(
         dataset, mask: str = "train",
         is_loader: bool = True, batch_size: int = 128,
-        num_workers: int = 0
+        num_workers: int = 0, shuffle: bool = False
 ) -> _typing.Union[torch.utils.data.DataLoader, _typing.Iterable]:
     r"""Get train/test dataset/dataloader after cross validation.
 
@@ -313,6 +313,8 @@ def graph_get_split(
         batch_size for generating Dataloader
     num_workers : int
         number of workers parameter for data loader
+    shuffle: bool
+        whether shuffle the dataloader
     """
     if not isinstance(mask, str):
         raise TypeError
@@ -369,7 +371,8 @@ def graph_get_split(
             from dgl.dataloading.pytorch import GraphDataLoader
             return GraphDataLoader(
                 sub_dataset,
-                **{"batch_size": batch_size, "num_workers": num_workers}
+                **{"batch_size": batch_size, "num_workers": num_workers},
+                shuffle=shuffle
             )
         elif _backend.DependentBackend.is_pyg():
             _sub_dataset: _typing.Any = optional_dataset_split
@@ -380,7 +383,7 @@ def graph_get_split(
             else:
                 from torch_geometric.data import DataLoader
             return DataLoader(
-                _sub_dataset, batch_size=batch_size, num_workers=num_workers
+                _sub_dataset, batch_size=batch_size, num_workers=num_workers, shuffle=shuffle
             )
     else:
         return sub_dataset

--- a/autogl/module/model/decoders/__init__.py
+++ b/autogl/module/model/decoders/__init__.py
@@ -12,16 +12,16 @@ if DependentBackend.is_pyg():
 else:
     from ._dgl import (
         LogSoftmaxDecoderMaintainer,
-        AddPoolMLPDecoderMaintainer,
+        JKSumPoolDecoderMaintainer,
         TopKDecoderMaintainer,
-        DotProductLinkPredictonDecoderMaintainer
+        DotProductLinkPredictionDecoderMaintainer
     )
 
 __all__ = [
     "BaseDecoderMaintainer",
     "DecoderUniversalRegistry",
     "LogSoftmaxDecoderMaintainer",
-    "AddPoolMLPDecoderMaintainer",
+    "JKSumPoolDecoderMaintainer",
     "TopKDecoderMaintainer",
     "DiffPoolDecoderMaintainer",
     "DotProductLinkPredictonDecoderMaintainer"

--- a/autogl/module/model/decoders/__init__.py
+++ b/autogl/module/model/decoders/__init__.py
@@ -5,7 +5,7 @@ from autogl.backend import DependentBackend
 if DependentBackend.is_pyg():
     from ._pyg import (
         LogSoftmaxDecoderMaintainer,
-        AddPoolMLPDecoderMaintainer,
+        SumPoolMLPDecoderMaintainer,
         DiffPoolDecoderMaintainer,
         DotProductLinkPredictonDecoderMaintainer
     )

--- a/autogl/module/model/decoders/_dgl/__init__.py
+++ b/autogl/module/model/decoders/_dgl/__init__.py
@@ -1,6 +1,7 @@
 from ._dgl_decoders import (
     LogSoftmaxDecoderMaintainer,
     JKSumPoolDecoderMaintainer,
+    SumPoolMLPDecoderMaintainer,
     TopKDecoderMaintainer,
     DotProductLinkPredictionDecoderMaintainer
 )

--- a/autogl/module/model/decoders/_dgl/__init__.py
+++ b/autogl/module/model/decoders/_dgl/__init__.py
@@ -1,6 +1,6 @@
 from ._dgl_decoders import (
     LogSoftmaxDecoderMaintainer,
-    AddPoolMLPDecoderMaintainer,
+    JKSumPoolDecoderMaintainer,
     TopKDecoderMaintainer,
-    DotProductLinkPredictonDecoderMaintainer
+    DotProductLinkPredictionDecoderMaintainer
 )

--- a/autogl/module/model/decoders/_dgl/_dgl_decoders.py
+++ b/autogl/module/model/decoders/_dgl/_dgl_decoders.py
@@ -6,6 +6,7 @@ from dgl.nn.pytorch.glob import (
 )
 from .. import base_decoder, decoder_registry
 from ...encoders import base_encoder
+from ... import _utils
 
 
 class _LogSoftmaxDecoder(torch.nn.Module):
@@ -110,6 +111,119 @@ class JKSumPoolDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
         self.hyper_parameters = {
             "dropout": 0.5,
             "graph_pooling_type": "sum"
+        }
+
+class _SumPoolMLPDecoder(torch.nn.Module):
+    def __init__(
+            self, _final_dimension: int, hidden_dimension: int, output_dimension: int,
+            _act: _typing.Optional[str], _dropout: _typing.Optional[float],
+            num_graph_features: _typing.Optional[int]
+    ):
+        super(_SumPoolMLPDecoder, self).__init__()
+        if (
+                isinstance(num_graph_features, int)
+                and num_graph_features > 0
+        ):
+            _final_dimension += num_graph_features
+            self.__num_graph_features: _typing.Optional[int] = num_graph_features
+        else:
+            self.__num_graph_features: _typing.Optional[int] = None
+        self._sumpool = SumPooling()
+        self._fc1: torch.nn.Linear = torch.nn.Linear(
+            _final_dimension, hidden_dimension
+        )
+        self._fc2: torch.nn.Linear = torch.nn.Linear(
+            hidden_dimension, output_dimension
+        )
+        self._act: _typing.Optional[str] = _act
+        self._dropout: _typing.Optional[float] = _dropout
+
+    def forward(
+            self, features: _typing.Sequence[torch.Tensor],
+            data: dgl.DGLGraph, *__args, **__kwargs
+    ):
+        feature = features[-1]
+        feature = self._sumpool(data, feature)
+        if (
+                isinstance(self.__num_graph_features, int)
+                and self.__num_graph_features > 0
+        ):
+            if (
+                    hasattr(data, 'gf') and
+                    isinstance(data.gf, torch.Tensor) and data.gf.dim() == 2 and
+                    data.gf.size() == (feature.size(0), self.__num_graph_features)
+            ):
+                graph_features: torch.Tensor = data.gf
+            else:
+                raise ValueError(
+                    f"The provided data is expected to contain property 'gf' "
+                    f"with {self.__num_graph_features} dimensions as graph feature"
+                )
+            feature: torch.Tensor = torch.cat([feature, graph_features], dim=-1)
+        feature: torch.Tensor = self._fc1(feature)
+        feature: torch.Tensor = _utils.activation.activation_func(feature, self._act)
+        if isinstance(self._dropout, float) and 0 <= self._dropout <= 1:
+            feature: torch.Tensor = torch.nn.functional.dropout(
+                feature, self._dropout, self.training
+            )
+        feature: torch.Tensor = self._fc2(feature)
+        return torch.nn.functional.log_softmax(feature, dim=-1)
+
+
+@decoder_registry.DecoderUniversalRegistry.register_decoder('SumPoolMLP'.lower())
+@decoder_registry.DecoderUniversalRegistry.register_decoder('SumPoolMLPDecoder'.lower())
+@decoder_registry.DecoderUniversalRegistry.register_decoder('SumPoolMLP_Decoder'.lower())
+class SumPoolMLPDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
+    def _initialize(self, encoder: base_encoder.AutoHomogeneousEncoderMaintainer, *args, **kwargs) -> _typing.Optional[bool]:
+        if (
+                isinstance(getattr(self, "num_graph_features"), int) and
+                getattr(self, "num_graph_features") > 0
+        ):
+            num_graph_features: _typing.Optional[int] = getattr(self, "num_graph_features")
+        else:
+            num_graph_features: _typing.Optional[int] = None
+        self._decoder = _SumPoolMLPDecoder(
+            tuple(encoder.get_output_dimensions())[-1],
+            self.hyper_parameters['hidden'], self.output_dimension,
+            self.hyper_parameters['act'], self.hyper_parameters['dropout'],
+            num_graph_features
+        ).to(self.device)
+        return True
+
+    def __init__(
+            self, output_dimension: _typing.Optional[int] = ...,
+            device: _typing.Union[torch.device, str, int, None] = ...,
+            *args, **kwargs
+    ):
+        super(SumPoolMLPDecoderMaintainer, self).__init__(
+            output_dimension, device, *args, **kwargs
+        )
+        self.num_graph_features = kwargs.get("num_graph_features", 0)
+        self.hyper_parameter_space = [
+            {
+                "parameterName": "hidden",
+                "type": "INTEGER",
+                "maxValue": 64,
+                "minValue": 8,
+                "scalingType": "LINEAR",
+            },
+            {
+                "parameterName": "act",
+                "type": "CATEGORICAL",
+                "feasiblePoints": ["leaky_relu", "relu", "elu", "tanh"],
+            },
+            {
+                "parameterName": "dropout",
+                "type": "DOUBLE",
+                "maxValue": 0.9,
+                "minValue": 0.1,
+                "scalingType": "LINEAR",
+            }
+        ]
+        self.hyper_parameters = {
+            "hidden": 32,
+            "act": "relu",
+            "dropout": 0.5
         }
 
 

--- a/autogl/module/model/decoders/_dgl/_dgl_decoders.py
+++ b/autogl/module/model/decoders/_dgl/_dgl_decoders.py
@@ -5,7 +5,6 @@ from dgl.nn.pytorch.glob import (
     SumPooling, AvgPooling, MaxPooling, SortPooling
 )
 from .. import base_decoder, decoder_registry
-from ... import _utils
 from ...encoders import base_encoder
 
 
@@ -18,8 +17,12 @@ class _LogSoftmaxDecoder(torch.nn.Module):
 
 
 @decoder_registry.DecoderUniversalRegistry.register_decoder('log_softmax')
+@decoder_registry.DecoderUniversalRegistry.register_decoder('log-softmax-decoder')
+@decoder_registry.DecoderUniversalRegistry.register_decoder('log-softmax_decoder')
+@decoder_registry.DecoderUniversalRegistry.register_decoder('log_softmax-decoder')
 @decoder_registry.DecoderUniversalRegistry.register_decoder('log_softmax_decoder')
 @decoder_registry.DecoderUniversalRegistry.register_decoder('LogSoftmax'.lower())
+@decoder_registry.DecoderUniversalRegistry.register_decoder('LogSoftmax-decoder'.lower())
 @decoder_registry.DecoderUniversalRegistry.register_decoder('LogSoftmax_decoder'.lower())
 class LogSoftmaxDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
     def _initialize(self, encoder, *args, **kwargs) -> _typing.Optional[bool]:
@@ -27,29 +30,19 @@ class LogSoftmaxDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
         return True
 
 
-class _AddPoolMLPDecoder(torch.nn.Module):
+class _JKSumPoolDecoder(torch.nn.Module):
     def __init__(
             self, input_dimensions: _typing.Sequence[int],
-            hidden_dimension: int, output_dimension: int,
-            act: _typing.Optional[str], dropout: _typing.Optional[float],
-            graph_pooling_type: str, gf_dimension: _typing.Optional[int],
+            output_dimension: int, dropout: float,
+            graph_pooling_type: str
     ):
-        super(_AddPoolMLPDecoder, self).__init__()
-        _input_dimension: int = input_dimensions[-1]
-        if isinstance(gf_dimension, int) and gf_dimension > 0:
-            _input_dimension += gf_dimension
-            self.__gf_dimension: _typing.Optional[int] = gf_dimension
-        else:
-            self.__gf_dimension: _typing.Optional[int] = None
-
-        self._act: _typing.Optional[str] = act
-        self._dropout: _typing.Optional[float] = dropout
-        self._fc1: torch.nn.Linear = torch.nn.Linear(
-            _input_dimension, hidden_dimension
-        )
-        self._fc2: torch.nn.Linear = torch.nn.Linear(
-            hidden_dimension, output_dimension
-        )
+        super(_JKSumPoolDecoder, self).__init__()
+        self._linear_transforms: torch.nn.ModuleList = torch.nn.ModuleList()
+        for input_dimension in input_dimensions:
+            self._linear_transforms.append(
+                torch.nn.Linear(input_dimension, output_dimension)
+            )
+        self._dropout: torch.nn.Dropout = torch.nn.Dropout(dropout)
         if not isinstance(graph_pooling_type, str):
             raise TypeError
         elif graph_pooling_type.lower() == 'sum':
@@ -64,49 +57,31 @@ class _AddPoolMLPDecoder(torch.nn.Module):
     def forward(
             self, features: _typing.Sequence[torch.Tensor],
             graph: dgl.DGLGraph, *__args, **__kwargs
-    ) -> torch.Tensor:
-        feature: torch.Tensor = features[-1]
-        if (
-                isinstance(self.__gf_dimension, int) and self.__gf_dimension > 0 and
-                hasattr(graph, 'gf') and isinstance(graph.gf, torch.Tensor)
-        ):
-            gf: torch.Tensor = getattr(graph, 'gf')
-            if not (gf.dim() == 2 and gf.size(1) == self.__gf_dimension):
-                raise ValueError
-            feature: torch.Tensor = torch.cat([feature, gf], dim=-1)
-        feature: torch.Tensor = self._fc1(feature)
-        feature: torch.Tensor = _utils.activation.activation_func(feature, self._act)
-        if (
-                isinstance(self._dropout, float)
-                and 0 <= self._dropout <= 1
-        ):
-            feature: torch.Tensor = torch.nn.functional.dropout(
-                feature, self._dropout, self.training
-            )
-        feature = self._fc2(feature)
-        feature = self.__pool(graph, feature)
-        return torch.nn.functional.log_softmax(feature, dim=-1)
+    ):
+        if len(features) != len(self._linear_transforms):
+            raise ValueError
+        score_over_layer = 0
+        for i, feature in enumerate(features):
+            score_over_layer += self._dropout(self._linear_transforms[i](self.__pool(graph, feature)))
+        return score_over_layer
 
 
-@decoder_registry.DecoderUniversalRegistry.register_decoder('AddPoolMLP'.lower())
-@decoder_registry.DecoderUniversalRegistry.register_decoder('AddPoolMLPDecoder'.lower())
-@decoder_registry.DecoderUniversalRegistry.register_decoder('AddPoolMLP_Decoder'.lower())
-class AddPoolMLPDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
+@decoder_registry.DecoderUniversalRegistry.register_decoder('JKSumPoolMLP')
+@decoder_registry.DecoderUniversalRegistry.register_decoder('JKSumPoolMLPDecoder')
+@decoder_registry.DecoderUniversalRegistry.register_decoder('JKSumPoolMLP-decoder')
+@decoder_registry.DecoderUniversalRegistry.register_decoder('JKSumPoolMLP-Decoder')
+@decoder_registry.DecoderUniversalRegistry.register_decoder('JKSumPoolMLP_decoder')
+@decoder_registry.DecoderUniversalRegistry.register_decoder('JKSumPoolMLP_Decoder')
+@decoder_registry.DecoderUniversalRegistry.register_decoder('JKSumPoolMLP'.lower())
+@decoder_registry.DecoderUniversalRegistry.register_decoder('JKSumPoolMLPDecoder'.lower())
+@decoder_registry.DecoderUniversalRegistry.register_decoder('JKSumPoolMLP-Decoder'.lower())
+@decoder_registry.DecoderUniversalRegistry.register_decoder('JKSumPoolMLP_Decoder'.lower())
+class JKSumPoolDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
     def _initialize(self, encoder: base_encoder.AutoHomogeneousEncoderMaintainer, *args, **kwargs) -> _typing.Optional[bool]:
-        self._decoder = _AddPoolMLPDecoder(
-            list(encoder.get_output_dimensions()),
-            self.hyper_parameters["hidden"], self.output_dimension,
-            self.hyper_parameters["act"], self.hyper_parameters["dropout"],
-            self.hyper_parameters["graph_pooling_type"],
-            gf_dimension=(
-                getattr(self, "num_graph_features")
-                if (
-                        hasattr(self, "num_graph_features") and
-                        isinstance(getattr(self, "num_graph_features"), int) and
-                        getattr(self, "num_graph_features") > 0
-                )
-                else None
-            )
+        self._decoder = _JKSumPoolDecoder(
+            list(encoder.get_output_dimensions()), self.output_dimension,
+            self.hyper_parameters["dropout"],
+            self.hyper_parameters["graph_pooling_type"]
         ).to(self.device)
         return True
 
@@ -115,22 +90,10 @@ class AddPoolMLPDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
             device: _typing.Union[torch.device, str, int, None] = ...,
             *args, **kwargs
     ):
-        super(AddPoolMLPDecoderMaintainer, self).__init__(
+        super(JKSumPoolDecoderMaintainer, self).__init__(
             output_dimension, device, *args, **kwargs
         )
         self.hyper_parameter_space = (
-            {
-                "parameterName": "hidden",
-                "type": "INTEGER",
-                "maxValue": 64,
-                "minValue": 8,
-                "scalingType": "LINEAR",
-            },
-            {
-                "parameterName": "act",
-                "type": "CATEGORICAL",
-                "feasiblePoints": ["leaky_relu", "relu", "elu", "tanh"],
-            },
             {
                 "parameterName": "dropout",
                 "type": "DOUBLE",
@@ -145,9 +108,7 @@ class AddPoolMLPDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
             }
         )
         self.hyper_parameters = {
-            "hidden": 64,
             "dropout": 0.5,
-            "act": "relu",
             "graph_pooling_type": "sum"
         }
 
@@ -179,7 +140,13 @@ class _TopKPoolDecoder(torch.nn.Module):
         return cumulative_result
 
 
+@decoder_registry.DecoderUniversalRegistry.register_decoder('TopK')
+@decoder_registry.DecoderUniversalRegistry.register_decoder('TopK-decoder')
+@decoder_registry.DecoderUniversalRegistry.register_decoder('TopK-Decoder')
+@decoder_registry.DecoderUniversalRegistry.register_decoder('TopK_decoder')
+@decoder_registry.DecoderUniversalRegistry.register_decoder('TopK_Decoder')
 @decoder_registry.DecoderUniversalRegistry.register_decoder('TopK'.lower())
+@decoder_registry.DecoderUniversalRegistry.register_decoder('TopK-decoder'.lower())
 @decoder_registry.DecoderUniversalRegistry.register_decoder('TopK_decoder'.lower())
 class TopKDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
     def _initialize(
@@ -213,23 +180,26 @@ class TopKDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
             "dropout": 0.5
         }
 
-class _DotProductLinkPredictonDecoder(torch.nn.Module):
-    def forward(self,
-        features: _typing.Sequence[torch.Tensor],
-        graph: dgl.DGLGraph,
-        pos_edge: torch.Tensor,
-        neg_edge: torch.Tensor,
-        **__kwargs
+
+class _DotProductLinkPredictionDecoder(torch.nn.Module):
+    def forward(
+            self,
+            features: _typing.Sequence[torch.Tensor],
+            graph: dgl.DGLGraph,
+            pos_edge: torch.Tensor,
+            neg_edge: torch.Tensor,
+            **__kwargs
     ):
         z = features[-1]
         edge_index = torch.cat([pos_edge, neg_edge], dim=-1)
-        logits = (z[edge_index[0]] * z[edge_index[1]]).sum(dim=-1)
-        return logits
+        return (z[edge_index[0]] * z[edge_index[1]]).sum(dim=-1)
 
-@decoder_registry.DecoderUniversalRegistry.register_decoder('lpdecoder'.lower())
-@decoder_registry.DecoderUniversalRegistry.register_decoder('dotproduct'.lower())
+
+@decoder_registry.DecoderUniversalRegistry.register_decoder('LPDecoder'.lower())
+@decoder_registry.DecoderUniversalRegistry.register_decoder('DOTProduct'.lower())
+@decoder_registry.DecoderUniversalRegistry.register_decoder('DOTProductDecoder'.lower())
 @decoder_registry.DecoderUniversalRegistry.register_decoder('lp-decoder'.lower())
 @decoder_registry.DecoderUniversalRegistry.register_decoder('dot-product'.lower())
-class DotProductLinkPredictonDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
+class DotProductLinkPredictionDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
     def _initialize(self, *args, **kwargs):
-        self._decoder = _DotProductLinkPredictonDecoder()
+        self._decoder = _DotProductLinkPredictionDecoder()

--- a/autogl/module/model/decoders/_pyg/__init__.py
+++ b/autogl/module/model/decoders/_pyg/__init__.py
@@ -1,6 +1,6 @@
 from ._pyg_decoders import (
     LogSoftmaxDecoderMaintainer,
-    AddPoolMLPDecoderMaintainer,
+    SumPoolMLPDecoderMaintainer,
     DiffPoolDecoderMaintainer,
     DotProductLinkPredictonDecoderMaintainer
 )

--- a/autogl/module/model/decoders/_pyg/_pyg_decoders.py
+++ b/autogl/module/model/decoders/_pyg/_pyg_decoders.py
@@ -26,13 +26,13 @@ class LogSoftmaxDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
         return True
 
 
-class _AddPoolMLPDecoder(torch.nn.Module):
+class _SumPoolMLPDecoder(torch.nn.Module):
     def __init__(
             self, _final_dimension: int, hidden_dimension: int, output_dimension: int,
             _act: _typing.Optional[str], _dropout: _typing.Optional[float],
             num_graph_features: _typing.Optional[int]
     ):
-        super(_AddPoolMLPDecoder, self).__init__()
+        super(_SumPoolMLPDecoder, self).__init__()
         if (
                 isinstance(num_graph_features, int)
                 and num_graph_features > 0
@@ -82,10 +82,10 @@ class _AddPoolMLPDecoder(torch.nn.Module):
         return torch.nn.functional.log_softmax(feature, dim=-1)
 
 
-@decoder_registry.DecoderUniversalRegistry.register_decoder('AddPoolMLP'.lower())
-@decoder_registry.DecoderUniversalRegistry.register_decoder('AddPoolMLPDecoder'.lower())
-@decoder_registry.DecoderUniversalRegistry.register_decoder('AddPoolMLP_Decoder'.lower())
-class AddPoolMLPDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
+@decoder_registry.DecoderUniversalRegistry.register_decoder('SumPoolMLP'.lower())
+@decoder_registry.DecoderUniversalRegistry.register_decoder('SumPoolMLPDecoder'.lower())
+@decoder_registry.DecoderUniversalRegistry.register_decoder('SumPoolMLP_Decoder'.lower())
+class SumPoolMLPDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
     def _initialize(self, encoder: base_encoder.AutoHomogeneousEncoderMaintainer, *args, **kwargs) -> _typing.Optional[bool]:
         if (
                 isinstance(getattr(self, "num_graph_features"), int) and
@@ -94,7 +94,7 @@ class AddPoolMLPDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
             num_graph_features: _typing.Optional[int] = getattr(self, "num_graph_features")
         else:
             num_graph_features: _typing.Optional[int] = None
-        self._decoder = _AddPoolMLPDecoder(
+        self._decoder = _SumPoolMLPDecoder(
             tuple(encoder.get_output_dimensions())[-1],
             self.hyper_parameters['hidden'], self.output_dimension,
             self.hyper_parameters['act'], self.hyper_parameters['dropout'],
@@ -107,7 +107,7 @@ class AddPoolMLPDecoderMaintainer(base_decoder.BaseDecoderMaintainer):
             device: _typing.Union[torch.device, str, int, None] = ...,
             *args, **kwargs
     ):
-        super(AddPoolMLPDecoderMaintainer, self).__init__(
+        super(SumPoolMLPDecoderMaintainer, self).__init__(
             output_dimension, device, *args, **kwargs
         )
         self.num_graph_features = kwargs.get("num_graph_features", 0)

--- a/autogl/module/model/dgl/gin.py
+++ b/autogl/module/model/dgl/gin.py
@@ -144,7 +144,7 @@ class GIN(torch.nn.Module):
         if not self.num_layers == len(self.args["hidden"]) + 1:
             LOGGER.warn("Warning: layer size does not match the length of hidden units")
 
-        self.eps = self.args["eps"]
+        self.eps = True if self.args["eps"]=="True" else False
         self.num_mlp_layers = self.args["mlp_layers"]
         input_dim = self.args["features_num"]
         hidden = self.args["hidden"]
@@ -167,7 +167,7 @@ class GIN(torch.nn.Module):
         self.ginlayers = torch.nn.ModuleList()
         self.batch_norms = torch.nn.ModuleList()
 
-        for layer in range(self.num_layers - 2):
+        for layer in range(self.num_layers - 1):
             if layer == 0:
                 mlp = MLP(self.num_mlp_layers, input_dim, hidden[layer], hidden[layer])
             else:
@@ -177,28 +177,19 @@ class GIN(torch.nn.Module):
                 GINConv(ApplyNodeFunc(mlp), neighbor_pooling_type, 0, self.eps))
             self.batch_norms.append(nn.BatchNorm1d(hidden[layer]))
 
-
-        self.fc1 = Linear(
-            hidden[self.num_layers - 3] + self.num_graph_features,
-            hidden[self.num_layers - 2],
-        )
-        self.fc2 = Linear(
-            hidden[self.num_layers - 2], self.args["num_class"]
-        )
-
         # Linear function for graph poolings of output of each layer
         # which maps the output of different layers into a prediction score
-        # self.linears_prediction = torch.nn.ModuleList()
+        self.linears_prediction = torch.nn.ModuleList()
 
-        # for layer in range(self.num_layers):
-        #     if layer == 0:
-        #         self.linears_prediction.append(
-        #             nn.Linear(input_dim, output_dim))
-        #     else:
-        #         self.linears_prediction.append(
-        #             nn.Linear(hidden[layer], output_dim))
+        for layer in range(self.num_layers):
+            if layer == 0:
+                self.linears_prediction.append(
+                    nn.Linear(input_dim, output_dim))
+            else:
+                self.linears_prediction.append(
+                    nn.Linear(hidden[layer-1], output_dim))
 
-        # self.drop = nn.Dropout(final_dropout)
+        self.drop = nn.Dropout(final_dropout)
 
         if graph_pooling_type == 'sum':
             self.pool = SumPooling()
@@ -209,7 +200,6 @@ class GIN(torch.nn.Module):
         else:
             raise NotImplementedError
 
-    #def forward(self, g, h):
     def forward(self, data):
         x = data.ndata.pop('feat')
 
@@ -217,29 +207,20 @@ class GIN(torch.nn.Module):
             graph_feature = data.gf
 
         # list of hidden representation at each layer (including input)
-        # hidden_rep = [h]
+        hidden_rep = [x]
 
-        for i in range(self.num_layers - 2):
+        for i in range(self.num_layers - 1):
             x = self.ginlayers[i](data, x)
-            x = activate_func(x, self.args["act"])
             x = self.batch_norms[i](x)
-            # h = F.relu(h)
-            # hidden_rep.append(h)
-        if self.num_graph_features > 0:
-            x = torch.cat([x, graph_feature], dim=-1)
-        x = self.fc1(x)
-        x = activate_func(x, self.args["act"])
-        x = F.dropout(x, p=self.args["dropout"], training=self.training)
+            x = activate_func(x, self.args["act"])
+            hidden_rep.append(x)
 
-        x = self.fc2(x)
-        x = self.pool(data, x)
-        return F.log_softmax(x, dim=1)
-        # score_over_layer = 0
+        score_over_layer = 0
         # perform pooling over all nodes in each graph in every layer
-        # for i, h in enumerate(hidden_rep):
-        #     pooled_h = self.pool(g, h)
-        #     score_over_layer += self.drop(self.linears_prediction[i](pooled_h))
-        # return score_over_layer
+        for i, h in enumerate(hidden_rep):
+            pooled_h = self.pool(data, h)
+            score_over_layer += self.drop(self.linears_prediction[i](pooled_h))
+        return score_over_layer
 
 
 @register_model("gin-model")
@@ -319,7 +300,7 @@ class AutoGIN(BaseAutoModel):
             {
                 "parameterName": "eps",
                 "type": "CATEGORICAL",
-                "feasiblePoints": ["True", "False"],
+                "feasiblePoints": [True, False],
             },
             {
                 "parameterName": "mlp_layers",
@@ -354,6 +335,7 @@ class AutoGIN(BaseAutoModel):
 
     def _initialize(self):
         # """Initialize model."""
+
         self._model = GIN({
             "features_num": self.input_dimension,
             "num_class": self.output_dimension,

--- a/autogl/module/model/dgl/hetero/HeteroRGCN.py
+++ b/autogl/module/model/dgl/hetero/HeteroRGCN.py
@@ -89,32 +89,28 @@ class HeteroRGCN(nn.Module):
 @register_model("HeteroRGCN")
 class AutoHeteroRGCN(BaseHeteroModelMaintainer):
     r"""
-    AutoHAN.
+    AutoHeteroRGCN.
     The model used in this automodel is HeteroRGCN, i.e., the relational graph convolutional network from the
     `"Modeling Relational Data with Graph Convolutional Networks"
     <https://arxiv.org/abs/1703.06103>`_ paper
 
-    .. math::
         
     Parameters
     ----------
-    G: ``autogl.data``
-        The Hetero Graph Data.
-    
-    meta_paths: ``List[List[str]]``
-        List of meth paths, each as a list of edge types.
-
-    num_features: ``int``
+    num_features: `int`.
         The dimension of features.
 
-    num_classes: ``int``
+    num_classes: `int`.
         The number of classes.
 
-    device: ``torch.device`` or ``str``
+    device: `torch.device` or `str`.
         The device where model will be running on.
 
     init: `bool`.
         If True(False), the model will (not) be initialized.
+
+    dataset: `autogl.datasets`.
+        Hetero Graph Dataset in autogl.
     """
     def __init__(
         self, num_features=None, num_classes=None, device=None, init=False, dataset=None, **args

--- a/autogl/module/model/dgl/hetero/han.py
+++ b/autogl/module/model/dgl/hetero/han.py
@@ -151,27 +151,23 @@ class AutoHAN(BaseHeteroModelMaintainer):
     `"Heterogenous Graph Attention Network"
     <https://arxiv.org/pdf/1903.07293.pdf>`_ paper.
 
-    .. math::
-        
+
     Parameters
     ----------
-    G: ``autogl.data``
-        The Hetero Graph Data.
-    
-    meta_paths: ``List[List[str]]``
-        List of meth paths, each as a list of edge types.
-
-    num_features: ``int``
+    num_features: `int`.
         The dimension of features.
 
-    num_classes: ``int``
+    num_classes: `int`.
         The number of classes.
 
-    device: ``torch.device`` or ``str``
+    device: `torch.device` or `str`.
         The device where model will be running on.
 
     init: `bool`.
         If True(False), the model will (not) be initialized.
+
+    dataset: `autogl.datasets`.
+        Hetero Graph Dataset in autogl.
     """
     def __init__(
         self, num_features=None, num_classes=None, device=None, init=False, dataset=None, **args

--- a/autogl/module/model/dgl/hetero/hgt.py
+++ b/autogl/module/model/dgl/hetero/hgt.py
@@ -183,28 +183,24 @@ class AutoHGT(BaseHeteroModelMaintainer):
     AutoHGT.
     The model used in this automodel is HGT, i.e., the graph convolutional network from the
     `"Heterogeneous Graph Transformer" <https://arxiv.org/abs/2003.01332>`_paper.
-
-    .. math::
         
     Parameters
     ----------
-    G: ``autogl.data``
-        The Hetero Graph Data.
-    
-    meta_paths: ``List[List[str]]``
-        List of meth paths, each as a list of edge types.
-
-    num_features: ``int``
+    num_features: `int`.
         The dimension of features.
 
-    num_classes: ``int``
+    num_classes: `int`.
         The number of classes.
 
-    device: ``torch.device`` or ``str``
+    device: `torch.device` or `str`.
         The device where model will be running on.
 
     init: `bool`.
         If True(False), the model will (not) be initialized.
+
+    dataset: `autogl.datasets`.
+        Hetero Graph Dataset in autogl.
+
     """
     def __init__(
         self, num_features=None, num_classes=None, device=None, init=False, dataset=None, **args

--- a/autogl/module/model/encoders/_dgl/_gat.py
+++ b/autogl/module/model/encoders/_dgl/_gat.py
@@ -167,11 +167,15 @@ class GATMaintainer(base_encoder.AutoHomogeneousEncoderMaintainer):
                 self.final_dimension > 0
         ):
             temp.append(self.final_dimension)
-        return GATUtils.to_total_hidden_dimensions(
-            temp,
-            self.hyper_parameters.get("num_hidden_heads", self.hyper_parameters["heads"]),
-            self.hyper_parameters.get("num_output_heads", 1)
+        output_dimensions = [self.input_dimension]
+        output_dimensions.extend(
+            GATUtils.to_total_hidden_dimensions(
+                temp,
+                self.hyper_parameters.get("num_hidden_heads", self.hyper_parameters["heads"]),
+                self.hyper_parameters.get("num_output_heads", 1)
+            )
         )
+        return output_dimensions
 
     def _initialize(self) -> _typing.Optional[bool]:
         dimensions = list(self.hyper_parameters["hidden"])

--- a/autogl/module/model/encoders/_dgl/_gcn.py
+++ b/autogl/module/model/encoders/_dgl/_gcn.py
@@ -27,7 +27,7 @@ class _GCN(torch.nn.Module):
 
     def forward(self, graph: dgl.DGLGraph, *__args, **__kwargs):
         x: torch.Tensor = graph.ndata['feat']
-        results: _typing.MutableSequence[torch.Tensor] = []
+        results: _typing.MutableSequence[torch.Tensor] = [x]
         for _layer in range(len(self.__convolution_layers)):
             x = self.__convolution_layers[_layer](graph, x)
             if _layer < len(self.__convolution_layers) - 1:

--- a/autogl/module/model/encoders/_dgl/_gin.py
+++ b/autogl/module/model/encoders/_dgl/_gin.py
@@ -107,11 +107,11 @@ class _GIN(torch.nn.Module):
     def forward(self, graph: dgl.DGLGraph, *__args, **__kwargs) -> _typing.Sequence[torch.Tensor]:
         x: torch.Tensor = graph.ndata['feat']
 
-        features: _typing.MutableSequence[torch.Tensor] = []
+        features: _typing.MutableSequence[torch.Tensor] = [x]
         for layer in range(self.__num_layers):
             x: torch.Tensor = self.__gin_layers[layer](graph, x)
-            x: torch.Tensor = _utils.activation.activation_func(x, self._act)
             x: torch.Tensor = self.__batch_normalizations[layer](x)
+            x: torch.Tensor = _utils.activation.activation_func(x, self._act)
             features.append(x)
 
         return features

--- a/autogl/module/model/encoders/_dgl/_sage.py
+++ b/autogl/module/model/encoders/_dgl/_sage.py
@@ -31,7 +31,7 @@ class _SAGE(torch.nn.Module):
     def forward(self, graph: dgl.DGLGraph, *args, **kwargs):
         x: torch.Tensor = graph.ndata['feat']
         x = torch.nn.functional.dropout(x, self._dropout, self.training)
-        results: _typing.MutableSequence[torch.Tensor] = []
+        results: _typing.MutableSequence[torch.Tensor] = [x]
         for _layer in range(len(self.__convolution_layers)):
             x = self.__convolution_layers[_layer](graph, x)
             if _layer < len(self.__convolution_layers) - 1:

--- a/autogl/module/model/encoders/_dgl/_topk.py
+++ b/autogl/module/model/encoders/_dgl/_topk.py
@@ -151,13 +151,3 @@ class AutoTopKMaintainer(base_encoder.AutoHomogeneousEncoderMaintainer):
             self.input_dimension, dimensions
         ).to(self.device)
         return True
-
-    def get_output_dimensions(self) -> _typing.Iterable[int]:
-        _output_dimensions = [self.input_dimension]
-        _output_dimensions.extend(self.hyper_parameters["hidden"])
-        if (
-                isinstance(self.final_dimension, int) and
-                self.final_dimension > 0
-        ):
-            _output_dimensions.append(self.final_dimension)
-        return _output_dimensions

--- a/autogl/module/model/encoders/_pyg/_gat.py
+++ b/autogl/module/model/encoders/_pyg/_gat.py
@@ -59,7 +59,7 @@ class _GAT(torch.nn.Module):
             edge_weight: _typing.Optional[torch.Tensor] = data.edge_weight
         else:
             edge_weight: _typing.Optional[torch.Tensor] = None
-        results: _typing.MutableSequence[torch.Tensor] = []
+        results: _typing.MutableSequence[torch.Tensor] = [x]
         for layer, _gat in enumerate(self.__convolution_layers):
             x: torch.Tensor = torch.nn.functional.dropout(
                 x, self._dropout, self.training
@@ -105,11 +105,15 @@ class GATEncoderMaintainer(base_encoder.AutoHomogeneousEncoderMaintainer):
                 self.final_dimension > 0
         ):
             temp.append(self.final_dimension)
-        return GATUtils.to_total_hidden_dimensions(
-            temp,
-            self.hyper_parameters['num_hidden_heads'],
-            self.hyper_parameters['num_output_heads']
+        output_dimensions = [self.input_dimension]
+        output_dimensions.extend(
+            GATUtils.to_total_hidden_dimensions(
+                temp,
+                self.hyper_parameters.get("num_hidden_heads", self.hyper_parameters["heads"]),
+                self.hyper_parameters.get("num_output_heads", 1)
+            )
         )
+        return output_dimensions
 
     def __init__(
             self,

--- a/autogl/module/model/encoders/_pyg/_gcn.py
+++ b/autogl/module/model/encoders/_pyg/_gcn.py
@@ -33,7 +33,7 @@ class _GCN(torch.nn.Module):
             edge_weight: _typing.Optional[torch.Tensor] = data.edge_weight
         else:
             edge_weight: _typing.Optional[torch.Tensor] = None
-        results: _typing.MutableSequence[torch.Tensor] = []
+        results: _typing.MutableSequence[torch.Tensor] = [x]
         for layer, convolution_layer in enumerate(self.__convolution_layers):
             x = convolution_layer(x, edge_index, edge_weight)
             if layer < len(self.__convolution_layers) - 1:

--- a/autogl/module/model/encoders/_pyg/_gin.py
+++ b/autogl/module/model/encoders/_pyg/_gin.py
@@ -67,7 +67,7 @@ class _GIN(torch.nn.Module):
         x: torch.Tensor = data.x
         edge_index: torch.Tensor = data.edge_index
 
-        results: _typing.MutableSequence[torch.Tensor] = []
+        results: _typing.MutableSequence[torch.Tensor] = [x]
         num_layers = len(self.__convolution_layers)
         for layer in range(num_layers):
             x: torch.Tensor = self.__convolution_layers[layer](x, edge_index)

--- a/autogl/module/model/encoders/_pyg/_sage.py
+++ b/autogl/module/model/encoders/_pyg/_sage.py
@@ -29,7 +29,7 @@ class _SAGE(torch.nn.Module):
     ) -> _typing.Sequence[torch.Tensor]:
         x: torch.Tensor = data.x
         edge_index: torch.LongTensor = data.edge_index
-        results: _typing.MutableSequence[torch.Tensor] = []
+        results: _typing.MutableSequence[torch.Tensor] = [x]
         for layer, convolution_layer in enumerate(self.__convolution_layers):
             x = convolution_layer(x, edge_index)
             if layer < len(self.__convolution_layers) - 1:

--- a/autogl/module/model/encoders/base_encoder.py
+++ b/autogl/module/model/encoders/base_encoder.py
@@ -89,7 +89,8 @@ class AutoHomogeneousEncoderMaintainer(BaseEncoderMaintainer):
     def get_output_dimensions(self) -> _typing.Iterable[int]:
         """"""
         ''' Note that this is a default implicit assumption '''
-        _output_dimensions = list(self.hyper_parameters["hidden"])
+        _output_dimensions = [self._input_dimension]
+        _output_dimensions.extend(self.hyper_parameters["hidden"])
         if (
                 isinstance(self.final_dimension, int) and
                 self.final_dimension > 0

--- a/autogl/module/train/base.py
+++ b/autogl/module/train/base.py
@@ -564,8 +564,7 @@ class BaseGraphClassificationTrainer(_BaseClassificationTrainer):
             self.encoder.output_dimension = num_classes
         elif isinstance(self.decoder, BaseDecoderMaintainer):
             self.decoder.output_dimension = num_classes
-        self.last_dim = num_classes
-    
+
     @property
     def num_graph_features(self):
         return self._num_graph_features

--- a/autogl/module/train/graph_classification_full.py
+++ b/autogl/module/train/graph_classification_full.py
@@ -210,7 +210,7 @@ class GraphClassificationFullTrainer(BaseGraphClassificationTrainer):
         else:
             scheduler = None
 
-        for epoch in range(1, self.max_epoch):
+        for epoch in range(1, self.max_epoch + 1):
             model.train()
             loss_all = 0
             for data in train_loader:
@@ -307,7 +307,7 @@ class GraphClassificationFullTrainer(BaseGraphClassificationTrainer):
 
         """
         train_loader = utils.graph_get_split(
-            dataset, "train", batch_size=self.batch_size, num_workers=self.num_workers
+            dataset, "train", batch_size=self.batch_size, num_workers=self.num_workers, shuffle=True
         )
         valid_loader = utils.graph_get_split(
             dataset, "val", batch_size=self.batch_size, num_workers=self.num_workers

--- a/autogl/module/train/graph_classification_full.py
+++ b/autogl/module/train/graph_classification_full.py
@@ -82,7 +82,7 @@ class GraphClassificationFullTrainer(BaseGraphClassificationTrainer):
         elif isinstance(model, BaseAutoModel):
             encoder, decoder = model, None
         else:
-            encoder, decoder = model, "addpoolmlp"
+            encoder, decoder = model, "sumpoolmlp"
 
         super().__init__(
             encoder=encoder,
@@ -90,7 +90,7 @@ class GraphClassificationFullTrainer(BaseGraphClassificationTrainer):
             num_features=num_features,
             num_classes=num_classes,
             num_graph_features=num_graph_features,
-            last_dim=num_classes,
+            last_dim="auto",
             device=device,
             feval=feval,
             loss=loss,

--- a/docs/docfile/tutorial/t_homo_graph_classification_gin.rst
+++ b/docs/docfile/tutorial/t_homo_graph_classification_gin.rst
@@ -17,12 +17,14 @@ Graph Isomorphism Network (GIN) is one graph classification model from `"How Pow
 The layer is
 
 .. math::
+
     \mathbf{x}^{\prime}_i = h_{\mathbf{\Theta}} \left( (1 + \epsilon) \cdot
     \mathbf{x}_i + \sum_{j \in \mathcal{N}(i)} \mathbf{x}_j \right)
 
 or
 
 .. math::
+
     \mathbf{X}^{\prime} = h_{\mathbf{\Theta}} \left( \left( \mathbf{A} +
     (1 + \epsilon) \cdot \mathbf{I} \right) \cdot \mathbf{X} \right),
 

--- a/docs/docfile/tutorial/t_homo_graph_classification_gin.rst
+++ b/docs/docfile/tutorial/t_homo_graph_classification_gin.rst
@@ -174,7 +174,7 @@ Hyperparameters in GIN:
 
 - eps: `str` - whether to train parameter :math:`epsilon` in the GIN layer.
 
-- mlp_layers: `int` - number of MLP layers for classification after pooling.
+- mlp_layers: `int` - number of MLP layers in the GIN layer.
 
 - neighbor_pooling_type: `str` - pooling type in the  GIN layer.
 

--- a/docs/docfile/tutorial/t_homo_graph_classification_gin.rst
+++ b/docs/docfile/tutorial/t_homo_graph_classification_gin.rst
@@ -1,0 +1,294 @@
+==========================
+Graph Classification Model
+==========================
+
+Building Graph Classification Modules
+=====================================
+
+In AutoGL, we support two graph classification models, ``gin`` and  ``topk``.
+
+AutoGIN
+>>>>>>>
+
+The graph isomorphism operator from the “How Powerful are Graph Neural Networks?” paper
+
+Graph Isomorphism Network (GIN) is one graph classification model from `"How Powerful are Graph Neural Networks" paper <https://arxiv.org/pdf/1810.00826.pdf>`_.
+
+The layer is
+
+.. math::
+    \mathbf{x}^{\prime}_i = h_{\mathbf{\Theta}} \left( (1 + \epsilon) \cdot
+    \mathbf{x}_i + \sum_{j \in \mathcal{N}(i)} \mathbf{x}_j \right)
+
+or
+
+.. math::
+    \mathbf{X}^{\prime} = h_{\mathbf{\Theta}} \left( \left( \mathbf{A} +
+    (1 + \epsilon) \cdot \mathbf{I} \right) \cdot \mathbf{X} \right),
+
+here :math:`h_{\mathbf{\Theta}}` denotes a neural network, *.i.e.* an MLP.
+
+PARAMETERS:
+- num_features: `int` - The dimension of features.
+
+- num_classes: `int` - The number of classes.
+
+- device: `torch.device` or `str` - The device where model will be running on.
+
+- init: `bool` - If True(False), the model will (not) be initialized.
+
+.. code-block:: python
+
+    class AutoGIN(BaseModel):
+        r"""
+        AutoGIN. The model used in this automodel is GIN, i.e., the graph isomorphism network from the `"How Powerful are
+        Graph Neural Networks?" <https://arxiv.org/abs/1810.00826>`_ paper. The layer is
+
+        .. math::
+            \mathbf{x}^{\prime}_i = h_{\mathbf{\Theta}} \left( (1 + \epsilon) \cdot
+            \mathbf{x}_i + \sum_{j \in \mathcal{N}(i)} \mathbf{x}_j \right)
+
+        or
+
+        .. math::
+            \mathbf{X}^{\prime} = h_{\mathbf{\Theta}} \left( \left( \mathbf{A} +
+            (1 + \epsilon) \cdot \mathbf{I} \right) \cdot \mathbf{X} \right),
+
+        here :math:`h_{\mathbf{\Theta}}` denotes a neural network, *.i.e.* an MLP.
+
+        Parameters
+        ----------
+        num_features: `int`.
+            The dimension of features.
+
+        num_classes: `int`.
+            The number of classes.
+
+        device: `torch.device` or `str`
+            The device where model will be running on.
+
+        init: `bool`.
+            If True(False), the model will (not) be initialized.
+        """
+
+        def __init__(
+            self,
+            num_features=None,
+            num_classes=None,
+            device=None,
+            init=False,
+            num_graph_features=None,
+            **args
+        ):
+
+            super(AutoGIN, self).__init__()
+            self.num_features = num_features if num_features is not None else 0
+            self.num_classes = int(num_classes) if num_classes is not None else 0
+            self.num_graph_features = (
+                int(num_graph_features) if num_graph_features is not None else 0
+            )
+            self.device = device if device is not None else "cpu"
+
+            self.params = {
+                "features_num": self.num_features,
+                "num_class": self.num_classes,
+                "num_graph_features": self.num_graph_features,
+            }
+            self.space = [
+                {
+                    "parameterName": "num_layers",
+                    "type": "DISCRETE",
+                    "feasiblePoints": "4,5,6",
+                },
+                {
+                    "parameterName": "hidden",
+                    "type": "NUMERICAL_LIST",
+                    "numericalType": "INTEGER",
+                    "length": 5,
+                    "minValue": [8, 8, 8, 8, 8],
+                    "maxValue": [64, 64, 64, 64, 64],
+                    "scalingType": "LOG",
+                    "cutPara": ("num_layers",),
+                    "cutFunc": lambda x: x[0] - 1,
+                },
+                {
+                    "parameterName": "dropout",
+                    "type": "DOUBLE",
+                    "maxValue": 0.9,
+                    "minValue": 0.1,
+                    "scalingType": "LINEAR",
+                },
+                {
+                    "parameterName": "act",
+                    "type": "CATEGORICAL",
+                    "feasiblePoints": ["leaky_relu", "relu", "elu", "tanh"],
+                },
+                {
+                    "parameterName": "eps",
+                    "type": "CATEGORICAL",
+                    "feasiblePoints": ["True", "False"],
+                },
+                {
+                    "parameterName": "mlp_layers",
+                    "type": "DISCRETE",
+                    "feasiblePoints": "2,3,4",
+                },
+                {
+                    "parameterName": "neighbor_pooling_type",
+                    "type": "CATEGORICAL",
+                    "feasiblePoints": ["sum", "mean", "max"],
+                },
+                {
+                    "parameterName": "graph_pooling_type",
+                    "type": "CATEGORICAL",
+                    "feasiblePoints": ["sum", "mean", "max"],
+                },
+            ]
+
+            self.hyperparams = {
+                "num_layers": 5,
+                "hidden": [64,64,64,64],
+                "dropout": 0.5,
+                "act": "relu",
+                "eps": "False",
+                "mlp_layers": 2,
+                "neighbor_pooling_type": "sum",
+                "graph_pooling_type": "sum"
+            }
+
+            self.initialized = False
+            if init is True:
+                self.initialize()
+
+Hyperparameters in GIN:
+
+- num_layers: `int` - number of GIN layers.
+  
+- hidden: `List[int]` - hidden size for each hidden layer.
+
+- dropout: `float` - dropout probability.
+
+- act: `str` - type of activation function.
+
+- eps: `str` - whether to train parameter :math:`epsilon` in the GIN layer.
+
+- mlp_layers: `int` - number of MLP layers for classification after pooling.
+
+- neighbor_pooling_type: `str` - pooling type in the  GIN layer.
+
+- graph_pooling_type: `str` - graph pooling type following the last GIN layer.
+
+
+You could get define your own ``gin`` model by using ``from_hyper_parameter`` function and specify the hyperpameryers.
+
+.. code-block:: python
+
+    # pyg version
+    from autogl.module.model.pyg import AutoGIN  
+    # from autogl.module.model.dgl import AutoGIN  # dgl version
+    model = AutoGIN(
+                    num_features=dataset.num_node_features,
+                    num_classes=dataset.num_classes,
+                    num_graph_features=0,
+                    init=False
+                ).from_hyper_parameter({
+                    # hp from model
+                    "num_layers": 5,
+                    "hidden": [64,64,64,64],
+                    "dropout": 0.5,
+                    "act": "relu",
+                    "eps": "False",
+                    "mlp_layers": 2,
+                    "neighbor_pooling_type": "sum",
+                    "graph_pooling_type": "sum"
+                }).model
+
+
+Then you can train the model for 100 epochs.
+
+.. code-block:: python
+
+    import torch.nn.functional as F
+
+    # Define the loss optimizer.
+    optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+
+    # Training
+    for epoch in range(100):
+        model.train()
+        for data in train_loader:
+            data = data.to(args.device)
+            optimizer.zero_grad()
+            output = model(data)
+            loss = F.nll_loss(output, data.y)
+            loss.backward()
+            optimizer.step()
+
+Finally, evaluate the trained model.
+
+.. code-block:: python
+
+    def test(model, loader, args):
+        model.eval()
+
+        correct = 0
+        for data in loader:
+            data = data.to(args.device)
+            output = model(data)
+            pred = output.max(dim=1)[1]
+            correct += pred.eq(data.y).sum().item()
+        return correct / len(loader.dataset)
+
+    acc = test(model, test_loader, args)
+
+
+Automatic Search for Graph Classification Tasks
+===============================================
+
+In AutoGL, we also provide a high-level API Solver to control the overall pipeline.
+We encapsulated the training process in the Building GNN Modules part for graph classification tasks
+in the solver ``AutoGraphClassifier`` that supports automatic hyperparametric optimization 
+as well as feature engineering and ensemble. In this part, we will show you how to use 
+``AutoGraphClassifier``.
+
+.. code-block:: python
+
+    solver = AutoGraphClassifier(
+                feature_module=None,
+                graph_models=[args.model],
+                hpo_module='random',
+                ensemble_module=None,
+                device=args.device, max_evals=1,
+                trainer_hp_space = fixed(
+                    **{
+                        # hp from trainer
+                        "max_epoch": args.epoch,
+                        "batch_size": args.batch_size, 
+                        "early_stopping_round": args.epoch + 1, 
+                        "lr": args.lr, 
+                        "weight_decay": 0,
+                    }
+                ),
+                model_hp_spaces=[
+                    fixed(**{
+                        # hp from model
+                        "num_layers": 5,
+                        "hidden": [64,64,64,64],
+                        "dropout": 0.5,
+                        "act": "relu",
+                        "eps": "False",
+                        "mlp_layers": 2,
+                        "neighbor_pooling_type": "sum",
+                        "graph_pooling_type": "sum"
+                    }) if args.model == 'gin' else fixed(**{
+                        "ratio": 0.8,
+                        "dropout": 0.5,
+                        "act": "relu"
+                    }),
+                ]
+            )
+    
+    # fit auto model
+    solver.fit(dataset, evaluation_method=['acc'])
+    # prediction
+    out = solver.predict(dataset, mask='test')

--- a/test/performance/graph_classification/dgl/base.py
+++ b/test/performance/graph_classification/dgl/base.py
@@ -6,7 +6,8 @@ Borrowed from DGL official examples: https://github.com/dmlc/dgl/tree/master/exa
 TopkPool is not supported currently
 """
 
-from dgl.dataloading.pytorch.dataloader import GraphDataLoader
+# from dgl.dataloading.pytorch.dataloader import GraphDataLoader
+from dgl.dataloading import GraphDataLoader
 import numpy as np
 from tqdm import tqdm
 
@@ -221,6 +222,7 @@ def train(net, trainloader, validloader, optimizer, criterion, epoch, device):
             optimizer.zero_grad()
             loss.backward()
             optimizer.step()
+
         
         gt = []
         pr = []
@@ -302,6 +304,10 @@ def main():
         model = GIN(
             5, 2, dataset_.dim_nfeats, 64, dataset_.gclasses, 0.5, False,
             "sum", "sum").to(device)
+
+        # for pname, p in model.named_parameters():
+        #     print(pname)
+        # assert False
 
         criterion = nn.CrossEntropyLoss()  # defaul reduce is true
         optimizer = optim.Adam(model.parameters(), lr=0.0001)

--- a/test/performance/graph_classification/dgl/helper.py
+++ b/test/performance/graph_classification/dgl/helper.py
@@ -1,12 +1,12 @@
 def get_encoder_decoder_hp(model='gin', decoder=None):
     if model == 'gin':
-        model_hp = {
+        model_hp =  {
             "num_layers": 5,
-            "hidden": [64],
+            "hidden": [64,64,64,64],
             "act": "relu",
             "eps": "False",
             "mlp_layers": 2,
-            "neighbor_pooling_type": "sum"
+            "neighbor_pooling_type": "sum",
         }
     elif model == 'gat':
         model_hp = {

--- a/test/performance/graph_classification/dgl/helper.py
+++ b/test/performance/graph_classification/dgl/helper.py
@@ -3,6 +3,7 @@ def get_encoder_decoder_hp(model='gin', decoder=None):
         model_hp =  {
             "num_layers": 5,
             "hidden": [64,64,64,64],
+            "dropout": 0.5,
             "act": "relu",
             "eps": "False",
             "mlp_layers": 2,
@@ -45,9 +46,14 @@ def get_encoder_decoder_hp(model='gin', decoder=None):
             "act": "relu",
             "graph_pooling_type": "sum"
         }
+    elif decoder == "JKSumPoolMLP":
+        decoder_hp = {
+            "dropout": 0.5,
+            "graph_pooling_type": "sum"
+        }
     elif decoder == "topk":
         decoder_hp = {
             "dropout": 0.5
         }
-    
+
     return model_hp, decoder_hp

--- a/test/performance/graph_classification/dgl/model.py
+++ b/test/performance/graph_classification/dgl/model.py
@@ -5,7 +5,8 @@ Performance check of AutoGL model + DGL (dataset + trainer)
 import os
 os.environ["AUTOGL_BACKEND"] = "dgl"
 
-from dgl.dataloading.pytorch.dataloader import GraphDataLoader
+# from dgl.dataloading.pytorch.dataloader import GraphDataLoader
+from dgl.dataloading import GraphDataLoader
 import numpy as np
 from tqdm import tqdm
 
@@ -57,9 +58,10 @@ def train(net, trainloader, validloader, optimizer, criterion, epoch, device):
 
             labels = labels.to(device)
             graphs = graphs.to(device)
-            outputs = net((graphs, labels))
+            # outputs = net((graphs, labels))
             # feat = graphs.ndata.pop('attr')
             # outputs = net(graphs, feat)
+            outputs = net(graphs)
 
             loss = criterion(outputs, labels)
 
@@ -76,7 +78,8 @@ def train(net, trainloader, validloader, optimizer, criterion, epoch, device):
             gt.append(labels)
             # feat = graphs.ndata.pop('attr')
             # outputs = net(graphs, feat)
-            outputs = net((graphs, labels))
+            # outputs = net((graphs, labels))
+            outputs = net(graphs)
             pr.append(outputs.argmax(1))
         gt = torch.cat(gt, dim=0)
         pr = torch.cat(pr, dim=0)
@@ -102,7 +105,8 @@ def eval_net(net, dataloader, device):
         # feat = graphs.ndata.pop('attr')
         total += len(labels)
         # outputs = net(graphs, feat)
-        outputs = net((graphs, labels))
+        # outputs = net((graphs, labels))
+        outputs = net(graphs)
         _, predicted = torch.max(outputs.data, 1)
 
         total_correct += (predicted == labels.data).sum().item()
@@ -146,7 +150,7 @@ def main(args):
                 device=device,
             ).from_hyper_parameter({
                 "num_layers": 5,
-                "hidden": [64],
+                "hidden": [64,64,64,64],
                 "dropout": 0.5,
                 "act": "relu",
                 "eps": "False",

--- a/test/performance/graph_classification/dgl/trainer.py
+++ b/test/performance/graph_classification/dgl/trainer.py
@@ -111,6 +111,7 @@ if __name__ == '__main__':
 
     model_hp, decoder_hp = get_encoder_decoder_hp(args.model)
 
+
     from tqdm import tqdm
     for seed in tqdm(range(10)):
         set_seed(seed)
@@ -135,7 +136,7 @@ if __name__ == '__main__':
             "encoder": model_hp,
             "decoder": decoder_hp
         })
-
+        print('trainer:',trainer)
         trainer.train(dataset, False)
         out = trainer.predict(dataset, 'test').detach().cpu().numpy()
         acc = (out == labels).astype('float').mean()

--- a/test/performance/graph_classification/dgl/trainer.py
+++ b/test/performance/graph_classification/dgl/trainer.py
@@ -55,23 +55,6 @@ class DatasetAbstraction():
             dataset.test_split = test
         return dataset
 
-def graph_get_split(
-    dataset, mask="train", is_loader=True, batch_size=128, num_workers=0
-):
-    assert hasattr(
-        dataset, "%s_split" % (mask)
-    ), "Given dataset do not have %s split" % (mask)
-    if is_loader:
-        return GraphDataLoader(
-            getattr(dataset, "%s_split" % (mask)),
-            batch_size=batch_size,
-            num_workers=num_workers,
-        )
-    else:
-        return getattr(dataset, "%s_split" % (mask))
-
-
-utils.graph_get_split = graph_get_split
 
 if __name__ == '__main__':
 
@@ -109,21 +92,25 @@ if __name__ == '__main__':
 
     accs = []
 
-    model_hp, decoder_hp = get_encoder_decoder_hp(args.model)
+    if args.model == "gin":
+        decoder = "JKSumPoolMLP"
+    else:
+        decoder = "sumpoolmlp"
 
+    model_hp, decoder_hp = get_encoder_decoder_hp(args.model, decoder=decoder)
 
     from tqdm import tqdm
-    for seed in tqdm(range(10)):
+    for seed in tqdm(range(args.repeat)):
         set_seed(seed)
 
         trainer = GraphClassificationFullTrainer(
-            model=args.model,
+            model=(args.model, decoder),
             device=args.device,
             init=False,
             num_features=dataset.graph[0].ndata['feat'].size(1),
             num_classes=dataset.gclasses,
             loss='cross_entropy',
-            feval = ('acc')
+            feval = ('acc',)
         ).duplicate_from_hyper_parameter({
             "trainer": {
                 # hp from trainer
@@ -136,9 +123,9 @@ if __name__ == '__main__':
             "encoder": model_hp,
             "decoder": decoder_hp
         })
-        print('trainer:',trainer)
+
         trainer.train(dataset, False)
         out = trainer.predict(dataset, 'test').detach().cpu().numpy()
         acc = (out == labels).astype('float').mean()
         accs.append(acc)
-    print('{:.4f} ~ {:.4f}'.format(np.mean(accs), np.std(accs)))
+    print('{:.2f} ~ {:.2f}'.format(np.mean(accs) * 100, np.std(accs) * 100))

--- a/test/performance/graph_classification/dgl/trainer_dataset.py
+++ b/test/performance/graph_classification/dgl/trainer_dataset.py
@@ -53,14 +53,19 @@ if __name__ == '__main__':
 
     accs = []
 
-    model_hp, decoder_hp = get_encoder_decoder_hp(args.model)
+    if args.model == "gin":
+        decoder = "JKSumPoolMLP"
+    else:
+        decoder = "sumpoolmlp"
+
+    model_hp, decoder_hp = get_encoder_decoder_hp(args.model, decoder)
 
     from tqdm import tqdm
     for seed in tqdm(range(args.repeat)):
         set_seed(seed)
 
         trainer = GraphClassificationFullTrainer(
-            model=args.model,
+            model=(args.model, decoder),
             device=args.device,
             init=False,
             num_features=dataset[0][0].ndata['feat'].size(1),
@@ -86,4 +91,4 @@ if __name__ == '__main__':
         out = trainer.predict(dataset, 'test').detach().cpu().numpy()
         acc = (out == labels).astype('float').mean()
         accs.append(acc)
-    print('{:.4f} ~ {:.4f}'.format(np.mean(accs), np.std(accs)))
+    print('{:.2f} ~ {:.2f}'.format(np.mean(accs) * 100, np.std(accs) * 100))

--- a/test/performance/graph_classification/pyg/base.py
+++ b/test/performance/graph_classification/pyg/base.py
@@ -157,8 +157,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # seed = 100
-    # dataset = TUDataset(os.path.expanduser('~/.pyg'), args.dataset)
-    dataset = TUDataset('./data', args.dataset)
+    dataset = TUDataset(os.path.expanduser('~/.pyg'), args.dataset)
     
     # 1. split dataset [fix split]
     dataids = list(range(len(dataset)))

--- a/test/performance/graph_classification/pyg/base.py
+++ b/test/performance/graph_classification/pyg/base.py
@@ -10,10 +10,11 @@ import torch.nn.functional as F
 from torch.nn import Sequential, Linear, ReLU
 import torch_geometric
 from torch_geometric.datasets import TUDataset
-if int(torch_geometric.__version__.split(",")[0]) >= 2:
-    from torch_geometric.loader import DataLoader
-else:
-    from torch_geometric.data import DataLoader
+from torch_geometric.loader import DataLoader
+# if int(torch_geometric.__version__.split(",")[0]) >= 2:
+#     from torch_geometric.loader import DataLoader
+# else:
+#     from torch_geometric.data import DataLoader
 from torch_geometric.nn import GINConv, global_add_pool, GraphConv, TopKPooling
 from torch_geometric.nn import global_mean_pool as gap, global_max_pool as gmp
 import logging
@@ -157,7 +158,8 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # seed = 100
-    dataset = TUDataset(os.path.expanduser('~/.pyg'), args.dataset)
+    # dataset = TUDataset(os.path.expanduser('~/.pyg'), args.dataset)
+    dataset = TUDataset('./data', args.dataset)
     
     # 1. split dataset [fix split]
     dataids = list(range(len(dataset)))

--- a/test/performance/graph_classification/pyg/base.py
+++ b/test/performance/graph_classification/pyg/base.py
@@ -10,11 +10,10 @@ import torch.nn.functional as F
 from torch.nn import Sequential, Linear, ReLU
 import torch_geometric
 from torch_geometric.datasets import TUDataset
-from torch_geometric.loader import DataLoader
-# if int(torch_geometric.__version__.split(",")[0]) >= 2:
-#     from torch_geometric.loader import DataLoader
-# else:
-#     from torch_geometric.data import DataLoader
+if int(torch_geometric.__version__.split(",")[0]) >= 2:
+    from torch_geometric.loader import DataLoader
+else:
+    from torch_geometric.data import DataLoader
 from torch_geometric.nn import GINConv, global_add_pool, GraphConv, TopKPooling
 from torch_geometric.nn import global_mean_pool as gap, global_max_pool as gmp
 import logging


### PR DESCRIPTION
### Notice
1. All the encoders for both PyG and DGL backend are modified, for that all **features of input graph** and all features conducted by intermediate layers are provided to decoder. (In contrast, previously only features conducted by intermediate layers are returned) Since the `JKSumPoolDecoder` needs to utilize original features. And other custom decoder should be able to leverage the original features of input graph.
2. `GraphClassificationFullTrainer` should be revised to NOT to specify the `final_dimension` for encoder. @Frozenmad Besides, correspondingly, the **name** of default decoder for graph classification should be changed as `'jksumpoolmlp'` for DGL Backend.
3. `SumPoolMLPDecoder` for DGL backend has not yet included in this branch at the moment, as it is non-trivial to migrate from PyG backend. I would appreciated if @BeiniXie is able to take this task, if she is convenient.