### PR TITLE
Revise universal registries

### DIFF
--- a/autogl/datasets/_dataset_registry.py
+++ b/autogl/datasets/_dataset_registry.py
@@ -1,45 +1,42 @@
 import os
 import typing as _typing
+from autogl.utils import universal_registry
 from autogl.data import Dataset
 
 
-class _DatasetUniversalRegistryMetaclass(type):
-    def __new__(
-            mcs, name: str, bases: _typing.Tuple[type, ...],
-            namespace: _typing.Dict[str, _typing.Any]
-    ):
-        return super(_DatasetUniversalRegistryMetaclass, mcs).__new__(
-            mcs, name, bases, namespace
-        )
-
-    def __init__(
-            cls, name: str, bases: _typing.Tuple[type, ...],
-            namespace: _typing.Dict[str, _typing.Any]
-    ):
-        super(_DatasetUniversalRegistryMetaclass, cls).__init__(name, bases, namespace)
-        cls._dataset_universal_registry: _typing.MutableMapping[str, _typing.Type[Dataset]] = {}
-
-
-class DatasetUniversalRegistry(metaclass=_DatasetUniversalRegistryMetaclass):
+class DatasetUniversalRegistry(universal_registry.UniversalRegistryBase):
     @classmethod
-    def register_dataset(cls, dataset_name: str):
+    def register_dataset(cls, dataset_name: str) -> _typing.Callable[
+        [_typing.Type[Dataset]], _typing.Type[Dataset]
+    ]:
         def register_dataset_cls(dataset: _typing.Type[Dataset]):
-            if dataset_name in cls._dataset_universal_registry:
-                raise ValueError(f"Dataset with name \"{dataset_name}\" already exists!")
-            elif not issubclass(dataset, Dataset):
+            if not issubclass(dataset, Dataset):
                 raise TypeError
             else:
-                cls._dataset_universal_registry[dataset_name] = dataset
+                cls[dataset_name] = dataset
                 return dataset
 
         return register_dataset_cls
 
     @classmethod
     def get_dataset(cls, dataset_name: str) -> _typing.Type[Dataset]:
-        return cls._dataset_universal_registry.get(dataset_name)
+        return cls[dataset_name]
 
 
 def build_dataset_from_name(dataset_name: str, path: str = "~/.cache-autogl/"):
+    """
+
+    Parameters
+    ----------
+    dataset_name: `str`
+        name of dataset
+    path: `str`
+        local cache directory for datasets, default to "~/.cache-autogl/"
+
+    Returns
+    -------
+    instance of dataset
+    """
     path = os.path.expanduser(os.path.join(path, "data", dataset_name))
     _dataset = DatasetUniversalRegistry.get_dataset(dataset_name)
     return _dataset(path)

--- a/autogl/datasets/_dgl.py
+++ b/autogl/datasets/_dgl.py
@@ -272,6 +272,10 @@ class ENZYMESDataset(InMemoryStaticGraphSet):
 
 
 @DatasetUniversalRegistry.register_dataset("imdb-b")
+@DatasetUniversalRegistry.register_dataset("imdb-binary")
+@DatasetUniversalRegistry.register_dataset("IMDBb".upper())
+@DatasetUniversalRegistry.register_dataset("IMDBBinary".upper())
+@DatasetUniversalRegistry.register_dataset("IMDBBinary")
 class IMDBBinaryDataset(InMemoryStaticGraphSet):
     def __init__(self, path: str):
         dgl_dataset = dgl.data.GINDataset(
@@ -306,6 +310,10 @@ class IMDBBinaryDataset(InMemoryStaticGraphSet):
 
 
 @DatasetUniversalRegistry.register_dataset("imdb-m")
+@DatasetUniversalRegistry.register_dataset("imdb-multi")
+@DatasetUniversalRegistry.register_dataset("IMDBm".upper())
+@DatasetUniversalRegistry.register_dataset("IMDBMulti".upper())
+@DatasetUniversalRegistry.register_dataset("IMDBMulti")
 class IMDBMultiDataset(InMemoryStaticGraphSet):
     def __init__(self, path: str):
         dgl_dataset = dgl.data.GINDataset(
@@ -340,6 +348,9 @@ class IMDBMultiDataset(InMemoryStaticGraphSet):
 
 
 @DatasetUniversalRegistry.register_dataset("reddit-b")
+@DatasetUniversalRegistry.register_dataset("reddit-binary")
+@DatasetUniversalRegistry.register_dataset("RedditB".upper())
+@DatasetUniversalRegistry.register_dataset("RedditBinary".upper())
 class RedditBinaryDataset(InMemoryStaticGraphSet):
     def __init__(self, path: str):
         dgl_dataset = dgl.data.GINDataset(
@@ -374,6 +385,7 @@ class RedditBinaryDataset(InMemoryStaticGraphSet):
 
 
 @DatasetUniversalRegistry.register_dataset("reddit-multi-5k")
+@DatasetUniversalRegistry.register_dataset("RedditMulti5K".upper())
 class REDDITMulti5KDataset(InMemoryStaticGraphSet):
     def __init__(self, path: str):
         dgl_dataset = dgl.data.GINDataset(

--- a/autogl/datasets/_pyg.py
+++ b/autogl/datasets/_pyg.py
@@ -292,6 +292,10 @@ class ENZYMESDataset(InMemoryStaticGraphSet):
 
 
 @DatasetUniversalRegistry.register_dataset("imdb-b")
+@DatasetUniversalRegistry.register_dataset("imdb-binary")
+@DatasetUniversalRegistry.register_dataset("IMDBb".upper())
+@DatasetUniversalRegistry.register_dataset("IMDBBinary".upper())
+@DatasetUniversalRegistry.register_dataset("IMDBBinary")
 class IMDBBinaryDataset(InMemoryStaticGraphSet):
     def __init__(self, path: str):
         pyg_dataset = TUDataset(os.path.join(path, '_pyg'), "IMDB-BINARY")
@@ -310,6 +314,10 @@ class IMDBBinaryDataset(InMemoryStaticGraphSet):
 
 
 @DatasetUniversalRegistry.register_dataset("imdb-m")
+@DatasetUniversalRegistry.register_dataset("imdb-multi")
+@DatasetUniversalRegistry.register_dataset("IMDBm".upper())
+@DatasetUniversalRegistry.register_dataset("IMDBMulti".upper())
+@DatasetUniversalRegistry.register_dataset("IMDBMulti")
 class IMDBMultiDataset(InMemoryStaticGraphSet):
     def __init__(self, path: str):
         pyg_dataset = TUDataset(os.path.join(path, '_pyg'), "IMDB-MULTI")
@@ -328,6 +336,9 @@ class IMDBMultiDataset(InMemoryStaticGraphSet):
 
 
 @DatasetUniversalRegistry.register_dataset("reddit-b")
+@DatasetUniversalRegistry.register_dataset("reddit-binary")
+@DatasetUniversalRegistry.register_dataset("RedditB".upper())
+@DatasetUniversalRegistry.register_dataset("RedditBinary".upper())
 class RedditBinaryDataset(InMemoryStaticGraphSet):
     def __init__(self, path: str):
         pyg_dataset = TUDataset(os.path.join(path, '_pyg'), "REDDIT-BINARY")
@@ -346,6 +357,7 @@ class RedditBinaryDataset(InMemoryStaticGraphSet):
 
 
 @DatasetUniversalRegistry.register_dataset("reddit-multi-5k")
+@DatasetUniversalRegistry.register_dataset("RedditMulti5K".upper())
 class REDDITMulti5KDataset(InMemoryStaticGraphSet):
     def __init__(self, path: str):
         pyg_dataset = TUDataset(os.path.join(path, '_pyg'), "REDDIT-MULTI-5K")
@@ -364,6 +376,7 @@ class REDDITMulti5KDataset(InMemoryStaticGraphSet):
 
 
 @DatasetUniversalRegistry.register_dataset("reddit-multi-12k")
+@DatasetUniversalRegistry.register_dataset("RedditMulti12K".upper())
 class REDDITMulti12KDataset(InMemoryStaticGraphSet):
     def __init__(self, path: str):
         pyg_dataset = TUDataset(os.path.join(path, '_pyg'), "REDDIT-MULTI-12K")

--- a/autogl/module/feature/_feature_engineer_registry.py
+++ b/autogl/module/feature/_feature_engineer_registry.py
@@ -1,5 +1,5 @@
 import typing as _typing
-
+from autogl.utils import universal_registry
 from ._base_feature_engineer import BaseFeatureEngineer
 
 
@@ -24,39 +24,26 @@ class _FeatureEngineerUniversalRegistryMetaclass(type):
         ] = {}
 
 
-class FeatureEngineerUniversalRegistry(metaclass=_FeatureEngineerUniversalRegistryMetaclass):
+class FeatureEngineerUniversalRegistry(universal_registry.UniversalRegistryBase):
     @classmethod
     def register_feature_engineer(cls, name: str) -> _typing.Callable[
         [_typing.Type[BaseFeatureEngineer]], _typing.Type[BaseFeatureEngineer]
     ]:
-        def register_fe(
-                fe: _typing.Type[BaseFeatureEngineer]
-        ) -> _typing.Type[BaseFeatureEngineer]:
-            if name in cls._feature_engineer_universal_registry:
-                raise ValueError(
-                    f"Feature Engineer with name \"{name}\" already exists!"
-                )
-            elif not issubclass(fe, BaseFeatureEngineer):
+        def register_fe(fe: _typing.Type[BaseFeatureEngineer]) -> _typing.Type[BaseFeatureEngineer]:
+            if not issubclass(fe, BaseFeatureEngineer):
                 raise TypeError
             else:
-                cls._feature_engineer_universal_registry[name] = fe
+                cls[name] = fe
                 return fe
+
         return register_fe
 
     @classmethod
     def get_feature_engineer(cls, name: str) -> _typing.Type[BaseFeatureEngineer]:
-        if name in cls._feature_engineer_universal_registry:
-            return cls._feature_engineer_universal_registry[name]
-        else:
+        if name not in cls:
             raise ValueError(f"cannot find feature engineer {name}")
+        else:
+            return cls[name]
 
 
-class _DeprecatedFeatureDict:
-    def __contains__(self, name: str) -> bool:
-        return name in FeatureEngineerUniversalRegistry._feature_engineer_universal_registry
-
-    def __getitem__(self, name: str) -> _typing.Type[BaseFeatureEngineer]:
-        return FeatureEngineerUniversalRegistry.get_feature_engineer(name)
-
-
-FEATURE_DICT = _DeprecatedFeatureDict()
+FEATURE_DICT = FeatureEngineerUniversalRegistry

--- a/autogl/module/model/decoders/decoder_registry.py
+++ b/autogl/module/model/decoders/decoder_registry.py
@@ -14,8 +14,6 @@ class DecoderUniversalRegistry(universal_registry.UniversalRegistryBase):
         ) -> _typing.Type[base_decoder.BaseDecoderMaintainer]:
             if not issubclass(_decoder, base_decoder.BaseDecoderMaintainer):
                 raise TypeError
-            elif name in cls:
-                raise ValueError
             else:
                 cls[name] = _decoder
                 return _decoder

--- a/autogl/module/model/encoders/encoder_registry.py
+++ b/autogl/module/model/encoders/encoder_registry.py
@@ -14,8 +14,6 @@ class EncoderUniversalRegistry(universal_registry.UniversalRegistryBase):
         ) -> _typing.Type[base_encoder.BaseEncoderMaintainer]:
             if not issubclass(_encoder, base_encoder.BaseEncoderMaintainer):
                 raise TypeError
-            elif name in cls:
-                raise ValueError
             else:
                 cls[name] = _encoder
                 return _encoder

--- a/autogl/utils/universal_registry.py
+++ b/autogl/utils/universal_registry.py
@@ -1,25 +1,58 @@
 import typing as _typing
 
 
-class _UniversalRegistryMetaclass(type):
-    def __getitem__(cls, k: str) -> _typing.Any:
-        return cls.__universal_registry[k]
+class _UniversalRegistryUtility:
+    @classmethod
+    def to_unique_identifier(cls, name: str) -> str:
+        if not isinstance(name, str):
+            raise TypeError
+        import re
+        return re.sub("[^A-Za-z0-9]", '', name.strip()).lower()
 
-    def __setitem__(cls, k: str, v: _typing.Any) -> None:
-        cls.__universal_registry[k] = v
+
+class _UniversalRegistryMetaclass(type):
+    def __getitem__(cls, k: str):
+        __identifier: str = _UniversalRegistryUtility.to_unique_identifier(k)
+        if __identifier in cls.__universal_registry:
+            return cls.__universal_registry[__identifier][0]
+        else:
+            raise KeyError(k)
+
+    def __setitem__(cls, k: str, v: type) -> None:
+        if not (isinstance(k, str) and isinstance(v, type)):
+            raise TypeError
+        __identifier: str = _UniversalRegistryUtility.to_unique_identifier(k)
+        if __identifier in cls.__universal_registry:
+            if not (
+                    v == cls.__universal_registry[__identifier][0] and
+                    id(v) == id(cls.__universal_registry[__identifier][0])
+            ):
+                raise ValueError
+            cls.__universal_registry[__identifier][1].add(k)
+        else:
+            cls.__universal_registry[__identifier] = (v, {k})
 
     def __delitem__(cls, k: str) -> None:
-        del cls.__universal_registry[k]
+        if not isinstance(k, str):
+            raise TypeError
+        __identifier: str = _UniversalRegistryUtility.to_unique_identifier(k)
+        if __identifier in cls.__universal_registry:
+            if k in cls.__universal_registry[__identifier][1]:
+                cls.__universal_registry[__identifier][1].remove(k)
+            if len(cls.__universal_registry[__identifier][1]) == 0:
+                del cls.__universal_registry[__identifier]
 
-    def __len__(cls) -> int:
-        return len(cls.__universal_registry)
+    def __contains__(cls, item):
+        if isinstance(item, str):
+            __identifier: str = _UniversalRegistryUtility.to_unique_identifier(item)
+            return __identifier in cls.__universal_registry
+        return False
 
     def __iter__(cls) -> _typing.Iterator[str]:
-        return iter(cls.__universal_registry)
-
-    @property
-    def _universal_registry(cls) -> _typing.Mapping[str, _typing.Any]:
-        return cls.__universal_registry
+        results: _typing.MutableSequence[str] = []
+        for __identifier, (_, names) in cls.__universal_registry.items():
+            results.extend(names)
+        return iter(results)
 
     def __new__(
             mcs, name: str, bases: _typing.Tuple[type, ...],
@@ -36,8 +69,12 @@ class _UniversalRegistryMetaclass(type):
         super(_UniversalRegistryMetaclass, cls).__init__(
             name, bases, namespace
         )
-        cls.__universal_registry: _typing.MutableMapping[str, _typing.Any] = {}
+        cls.__universal_registry: _typing.MutableMapping[
+            str, _typing.Tuple[type, _typing.MutableSet[str]]
+        ] = {}
 
 
 class UniversalRegistryBase(metaclass=_UniversalRegistryMetaclass):
-    ...
+    @classmethod
+    def to_unique_identifier(cls, name: str) -> str:
+        return _UniversalRegistryUtility.to_unique_identifier(name)


### PR DESCRIPTION
Revise universal registries to support similar names, use only english characters (lower form) `a-z` and digits `0-9` to distinguish entities in specific repository. For instance, `A01`, `a01`, `A-_01`, `A-01`, `a-0-1` are assumed to represent same entity in one specific repository.