### PR TITLE
Develop preprocessing module

### DIFF
--- a/autogl/module/preprocessing/__init__.py
+++ b/autogl/module/preprocessing/__init__.py
@@ -1,0 +1,1 @@
+""" preprocessing """

--- a/autogl/module/preprocessing/_data_preprocessor/__init__.py
+++ b/autogl/module/preprocessing/_data_preprocessor/__init__.py
@@ -1,0 +1,6 @@
+import autogl
+
+if autogl.backend.DependentBackend.is_dgl():
+    from ._data_preprocessor_dgl import DataPreprocessor
+else:
+    from ._data_preprocessor import DataPreprocessor

--- a/autogl/module/preprocessing/_data_preprocessor/_data_preprocessor.py
+++ b/autogl/module/preprocessing/_data_preprocessor/_data_preprocessor.py
@@ -1,0 +1,121 @@
+import copy
+import torch
+import typing
+import autogl.data.graph
+
+
+class _AbstractDataPreprocessor:
+    def fit(self, dataset):
+        raise NotImplementedError
+
+    def transform(self, dataset, inplace: bool = True):
+        raise NotImplementedError
+
+    def fit_transform(self, dataset, inplace: bool = True):
+        raise NotImplementedError
+
+
+class _ComposedDataPreprocessor(_AbstractDataPreprocessor):
+    def __init__(self, data_preprocessors: typing.Iterable[_AbstractDataPreprocessor]):
+        self.__data_preprocessors: typing.MutableSequence[_AbstractDataPreprocessor] = []
+        for preprocessor in data_preprocessors:
+            if isinstance(preprocessor, _ComposedDataPreprocessor):
+                self.__data_preprocessors.extend(preprocessor.__data_preprocessors)
+            else:
+                self.__data_preprocessors.append(preprocessor)
+
+    def fit(self, dataset):
+        for preprocessor in self.__data_preprocessors:
+            dataset = preprocessor.fit(dataset)
+        return dataset
+
+    def transform(self, dataset, inplace: bool = True):
+        for preprocessor in self.__data_preprocessors:
+            dataset = preprocessor.transform(dataset, inplace)
+        return dataset
+
+    def fit_transform(self, dataset, inplace: bool = True):
+        for preprocessor in self.__data_preprocessors:
+            dataset = preprocessor.fit_transform(dataset, inplace)
+        return dataset
+
+    def __and__(self, other: _AbstractDataPreprocessor):
+        return _ComposedDataPreprocessor((self, other))
+
+
+class _DataPreprocessor(_AbstractDataPreprocessor):
+    def __and__(self, other):
+        return _ComposedDataPreprocessor((self, other))
+
+    def _preprocess(
+            self, data: typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]
+    ) -> typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]:
+        raise NotImplementedError
+
+    def _postprocess(
+            self, data: typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]
+    ) -> typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]:
+        raise NotImplementedError
+
+    def _fit(
+            self, data: typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]
+    ) -> typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]:
+        raise NotImplementedError
+
+    def _transform(
+            self, data: typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]
+    ) -> typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]:
+        raise NotImplementedError
+
+    def fit(self, dataset):
+        raise NotImplementedError
+
+    def transform(self, dataset, inplace: bool = True):
+        raise NotImplementedError
+
+    def fit_transform(self, dataset, inplace: bool = True):
+        raise NotImplementedError
+
+
+class DataPreprocessor(_DataPreprocessor):
+    def fit(self, dataset):
+        with torch.no_grad():
+            for i, data in enumerate(dataset):
+                dataset[i] = self._postprocess(self._fit(self._preprocess(data)))
+            return dataset
+
+    def transform(self, dataset, inplace: bool = True):
+        if not inplace:
+            dataset = copy.deepcopy(dataset)
+        with torch.no_grad():
+            for i, data in enumerate(dataset):
+                dataset[i] = self._postprocess(self._transform(self._preprocess(data)))
+        return dataset
+
+    def fit_transform(self, dataset, inplace: bool = True):
+        if not inplace:
+            dataset = copy.deepcopy(dataset)
+        with torch.no_grad():
+            for i, data in enumerate(dataset):
+                dataset[i] = self._postprocess(self._transform(self._fit(self._preprocess(data))))
+        return dataset
+
+    def _preprocess(
+            self, data: typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]
+    ) -> typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]:
+        return data
+
+    def _postprocess(
+            self, data: typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]
+    ) -> typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]:
+        return data
+
+    def _fit(
+            self, data: typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]
+    ) -> typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]:
+        return data
+
+    def _transform(
+            self, data: typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]
+    ) -> typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]:
+        return data

--- a/autogl/module/preprocessing/_data_preprocessor/_data_preprocessor_dgl.py
+++ b/autogl/module/preprocessing/_data_preprocessor/_data_preprocessor_dgl.py
@@ -1,0 +1,56 @@
+import copy
+import torch
+import typing
+import dgl
+import autogl.data.graph
+import autogl.data.graph.utils.conversion
+from . import _data_preprocessor
+
+
+class DataPreprocessor(_data_preprocessor.DataPreprocessor):
+    @classmethod
+    def __preprocess(
+            cls, data: typing.Union[dgl.DGLGraph, autogl.data.graph.GeneralStaticGraph, typing.Any]
+    ) -> typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]:
+        if isinstance(data, dgl.DGLGraph):
+            graph = autogl.data.graph.utils.conversion.dgl_graph_to_general_static_graph(data)
+            setattr(graph, '__ORIGINAL_TYPE_BEFORE_PREPROCESSING', 'DGLGraph')
+            return graph
+        else:
+            return data
+
+    @classmethod
+    def __postprocess(
+            cls, data: typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]
+    ) -> typing.Union[dgl.DGLGraph, autogl.data.graph.GeneralStaticGraph, typing.Any]:
+        if (
+                isinstance(data, autogl.data.graph.GeneralStaticGraph) and
+                hasattr(data, '__ORIGINAL_TYPE_BEFORE_PREPROCESSING') and
+                isinstance(getattr(data, '__ORIGINAL_TYPE_BEFORE_PREPROCESSING', ...), str) and
+                getattr(data, '__ORIGINAL_TYPE_BEFORE_PREPROCESSING', ...) == 'DGLGraph'
+        ):
+            return autogl.data.graph.utils.conversion.general_static_graph_to_dgl_graph(data)
+        else:
+            return data
+
+    def fit(self, dataset):
+        with torch.no_grad():
+            for i, data in enumerate(dataset):
+                dataset[i] = self.__postprocess(self._postprocess(self._fit(self._preprocess(self.__preprocess(data)))))
+            return dataset
+
+    def transform(self, dataset, inplace: bool = True):
+        if not inplace:
+            dataset = copy.deepcopy(dataset)
+        with torch.no_grad():
+            for i, data in enumerate(dataset):
+                dataset[i] = self.__postprocess(self._postprocess(self._transform(self._preprocess(self.__preprocess(data)))))
+        return dataset
+
+    def fit_transform(self, dataset, inplace: bool = True):
+        if not inplace:
+            dataset = copy.deepcopy(dataset)
+        with torch.no_grad():
+            for i, data in enumerate(dataset):
+                dataset[i] = self.__postprocess(self._postprocess(self._transform(self._fit(self._preprocess(self.__preprocess(data))))))
+        return dataset

--- a/autogl/module/preprocessing/_data_preprocessor_registry.py
+++ b/autogl/module/preprocessing/_data_preprocessor_registry.py
@@ -1,0 +1,28 @@
+import typing
+from autogl.utils import universal_registry
+from . import _data_preprocessor
+
+
+class DataPreprocessorUniversalRegistry(universal_registry.UniversalRegistryBase):
+    @classmethod
+    def register_data_preprocessor(cls, name: str) -> typing.Callable[
+        [typing.Type[_data_preprocessor.DataPreprocessor]],
+        typing.Type[_data_preprocessor.DataPreprocessor]
+    ]:
+        def register_data_preprocessor(
+                data_preprocessor: typing.Type[_data_preprocessor.DataPreprocessor]
+        ) -> typing.Type[_data_preprocessor.DataPreprocessor]:
+            if not issubclass(data_preprocessor, _data_preprocessor.DataPreprocessor):
+                raise TypeError
+            else:
+                cls[name] = data_preprocessor
+                return data_preprocessor
+
+        return register_data_preprocessor
+
+    @classmethod
+    def get_data_preprocessor(cls, name: str) -> typing.Type[_data_preprocessor.DataPreprocessor]:
+        if name not in cls:
+            raise ValueError(f"Data Preprocessor with name \"{name}\" not exist")
+        else:
+            return cls[name]

--- a/autogl/module/preprocessing/feature_engineering/__init__.py
+++ b/autogl/module/preprocessing/feature_engineering/__init__.py
@@ -1,0 +1,61 @@
+from ._generators import (
+    OneHotFeatureGenerator,
+    EigenFeatureGenerator,
+    GraphletGenerator,
+    PageRankFeatureGenerator,
+    LocalDegreeProfileGenerator,
+    NormalizeFeatures,
+    OneHotDegreeGenerator
+)
+from ._graph import (
+    NetLSD,
+    NXLargeCliqueSize,
+    NXDegreeAssortativityCoefficient,
+    NXDegreePearsonCorrelationCoefficient,
+    NXHasBridges,
+    NXGraphCliqueNumber,
+    NXGraphNumberOfCliques,
+    NXTransitivity,
+    NXAverageClustering,
+    NXIsConnected,
+    NXNumberConnectedComponents,
+    NXIsDistanceRegular,
+    NXLocalEfficiency,
+    NXGlobalEfficiency,
+    NXIsEulerian,
+)
+from ._selectors import (
+    FilterConstant, GBDTFeatureSelector
+)
+from ._auto_feature_engineer import (
+    IdentityFeature, AutoFeatureEngineer
+)
+
+__all__ = [
+    "OneHotFeatureGenerator",
+    "EigenFeatureGenerator",
+    "GraphletGenerator",
+    "PageRankFeatureGenerator",
+    "LocalDegreeProfileGenerator",
+    "NormalizeFeatures",
+    "OneHotDegreeGenerator",
+    "NetLSD",
+    "NXLargeCliqueSize",
+    "NXDegreeAssortativityCoefficient",
+    "NXDegreePearsonCorrelationCoefficient",
+    "NXHasBridges",
+    "NXGraphCliqueNumber",
+    "NXGraphNumberOfCliques",
+    "NXTransitivity",
+    "NXAverageClustering",
+    "NXIsConnected",
+    "NXNumberConnectedComponents",
+    "NXIsDistanceRegular",
+    "NXLocalEfficiency",
+    "NXGlobalEfficiency",
+    "NXIsEulerian",
+    "FilterConstant",
+    "GBDTFeatureSelector",
+    "IdentityFeature",
+    "AutoFeatureEngineer"
+]

--- a/autogl/module/preprocessing/feature_engineering/_auto_feature_engineer.py
+++ b/autogl/module/preprocessing/feature_engineering/_auto_feature_engineer.py
@@ -1,0 +1,271 @@
+import time
+import numpy as np
+import torch
+import typing as _typing
+from sklearn import preprocessing
+from sklearn.metrics.pairwise import cosine_similarity
+import tqdm
+import tabulate
+import autogl.data.graph
+from ._feature_engineer import FeatureEngineer
+from .._data_preprocessor_registry import DataPreprocessorUniversalRegistry
+from ._selectors import GBDTFeatureSelector
+from ....utils import get_logger
+
+LOGGER = get_logger("Feature")
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("identity")
+class IdentityFeature(FeatureEngineer):
+    ...
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("OnlyConst".lower())
+class OnlyConstFeature(FeatureEngineer):
+    def _transform(
+            self, data: _typing.Union[autogl.data.graph.GeneralStaticGraph, _typing.Any]
+    ) -> _typing.Union[autogl.data.graph.GeneralStaticGraph, _typing.Any]:
+        if isinstance(data, autogl.data.graph.GeneralStaticGraph):
+            for node_t in data.nodes:
+                for candidate_feature_key in ('feat', 'x'):
+                    if candidate_feature_key in data.nodes[node_t].data:
+                        data.nodes[node_t].data[candidate_feature_key] = torch.ones(
+                            (data.nodes[node_t].data[candidate_feature_key].size(0), 1)
+                        ).to(data.nodes[node_t].data[candidate_feature_key])
+                    elif len(data.nodes[node_t].data) > 0:
+                        _ref = data.nodes[node_t].data[list(data.nodes[node_t].data)[0]]
+                        data.nodes[node_t].data[candidate_feature_key] = (
+                            torch.ones((_ref.size(0), 1)).to(_ref)
+                        )
+                    else:
+                        data.nodes[node_t].data[candidate_feature_key] = torch.ones(
+                            (torch.unique(data.edges.connections).size(0), 1)
+                        )
+        elif hasattr(data, 'x') and isinstance(data.x, torch.Tensor):
+            data.x = torch.ones((data.x.shape[0], 1)).to(data.x)
+        elif hasattr(data, 'edge_index') and isinstance(data.edge_index, torch.Tensor):
+            data.x = torch.ones((torch.unique(data.edge_index).size(0), 1)).to(data.edge_index)
+        else:
+            raise ValueError("Unsupported provided data")
+        return data
+
+
+def op_sum(x, nbs):
+    res = np.zeros_like(x)
+    for u in range(len(nbs)):
+        nb = nbs[u]
+        if len(nb != 0):
+            res[u] = np.sum(x[nb], axis=0)
+    return res
+
+
+def op_mean(x, nbs):
+    res = np.zeros_like(x)
+    for u in range(len(nbs)):
+        nb = nbs[u]
+        if len(nb != 0):
+            res[u] = np.mean(x[nb], axis=0)
+    return res
+
+
+def op_max(x, nbs):
+    res = np.zeros_like(x)
+    for u in range(len(nbs)):
+        nb = nbs[u]
+        if len(nb != 0):
+            res[u] = np.max(x[nb], axis=0)
+    return res
+
+
+def op_min(x, nbs):
+    res = np.zeros_like(x)
+    for u in range(len(nbs)):
+        nb = nbs[u]
+        if len(nb != 0):
+            res[u] = np.min(x[nb], axis=0)
+    return res
+
+
+def op_prod(x, nbs):
+    res = np.zeros_like(x)
+    for u in range(len(nbs)):
+        nb = nbs[u]
+        if len(nb != 0):
+            res[u] = np.prod(x[nb], axis=0)
+    return res
+
+
+mms = preprocessing.MinMaxScaler()
+ss = preprocessing.StandardScaler()
+
+
+def scale(x):
+    return ss.fit_transform(x)
+
+
+class Timer:
+    def __init__(self, timebudget=None):
+        self._timebudget = timebudget
+        self._esti_time = 0
+        self._g_start = time.time()
+
+    def start(self):
+        self._start = time.time()
+
+    def end(self):
+        time_use = time.time() - self._start
+        self._esti_time = (self._esti_time + time_use) / 2
+
+    def is_timeout(self):
+        timebudget = self._timebudget
+        if timebudget:
+            timebudget = self._timebudget - (time.time() - self._g_start)
+            if timebudget < self._esti_time:
+                return True
+        return False
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor('DeepGL'.lower())
+class AutoFeatureEngineer(FeatureEngineer):
+    r"""
+    Notes
+    -----
+    An implementation of auto feature engineering method Deepgl [#]_ ,which iteratively generates features by aggregating neighbour features
+    and select a fixed number of  features to automatically add important graph-aware features.
+    References
+    ----------
+    .. [#] Rossi, R. A., Zhou, R., & Ahmed, N. K. (2020).
+        Deep Inductive Graph Representation Learning.
+        IEEE Transactions on Knowledge and Data Engineering, 32(3), 438–452.
+        https://doi.org/10.1109/TKDE.2018.2878247
+    Parameters
+    ----------
+    fix_length : int
+        fixed number of features for every epoch. The final number of features added will be
+        ``fixlen`` \times ``max_epoch``, 200 \times 5 in default.
+    max_epoch : int
+        number of epochs in total process.
+    time_budget : int
+        timebudget(seconds) for the feature engineering process, None for no time budget . Note that
+        this time budget is a soft budget ,which is obtained by rough time estimation through previous iterations and
+        may finally exceed the actual timebudget
+    y_sel_func : Callable
+        feature selector function object for selection at each iteration ,lightgbm in default. Note that in original paper,
+        connected components of feature graph is used , and you may implement it by yourself if you want.
+    verbosity : int
+        hide any infomation except error and fatal if ``verbosity`` < 1
+    """
+
+    def __init__(
+            self,
+            fix_length: int = 200,
+            max_epoch: int = 5,
+            time_budget: _typing.Optional[int] = None,
+            feature_selector=GBDTFeatureSelector,
+            verbosity: int = 0,
+            *args, **kwargs
+    ):
+        super(AutoFeatureEngineer, self).__init__()
+        self._ops = [op_sum, op_mean, op_max, op_min]
+        self._sim = cosine_similarity
+        self._fixlen = fix_length
+        self._max_epoch = max_epoch
+        self._timebudget = time_budget
+        self._feature_selector = feature_selector(
+            fix_length, verbose_eval=verbosity >= 1, *args, **kwargs
+        )
+        self._verbosity = verbosity
+
+    def _gen(self, x) -> np.ndarray:
+        res = []
+        for i, op in enumerate(self._ops):
+            res.append(op(x, self.__neighbours))
+        res = np.concatenate(res, axis=1)
+        return res
+
+    def _fit(self, homogeneous_static_graph: autogl.data.graph.GeneralStaticGraph):
+        if not (
+                homogeneous_static_graph.nodes.is_homogeneous and
+                homogeneous_static_graph.edges.is_homogeneous
+        ):
+            raise ValueError
+        if 'x' in homogeneous_static_graph.nodes.data:
+            _feature_key = 'x'
+            _original_features: torch.Tensor = (
+                homogeneous_static_graph.nodes.data['x']
+            )
+        elif 'feat' in homogeneous_static_graph.nodes.data:
+            _feature_key = 'feat'
+            _original_features: torch.Tensor = (
+                homogeneous_static_graph.nodes.data['feat']
+            )
+        else:
+            raise ValueError
+
+        num_nodes = _original_features.size(0)
+        neighbours = [[] for _ in range(num_nodes)]
+        for u, v in homogeneous_static_graph.edges.connections.t().numpy():
+            neighbours[u].append(v)
+        self.__neighbours: _typing.Sequence[np.ndarray] = tuple(
+            [np.array(v) for v in neighbours]
+        )
+
+        x: np.ndarray = _original_features.numpy()
+        gx: np.ndarray = x.copy()
+        verbs = []
+        soft_timer = Timer(self._timebudget)
+        self._selection = []
+        for epoch in tqdm.tqdm(range(self._max_epoch), disable=self._verbosity <= 0):
+            soft_timer.start()
+            verb = [epoch, gx.shape[1]]
+            gx = self._gen(gx)
+            gx = scale(gx)
+            verb.append(gx.shape[1])
+
+            homogeneous_static_graph.nodes.data[_feature_key] = torch.from_numpy(gx)
+            self._feature_selector._fit(homogeneous_static_graph)
+            self._selection.append(self._feature_selector._selection)
+            homogeneous_static_graph = self._feature_selector._transform(
+                homogeneous_static_graph
+            )
+
+            gx: np.ndarray = homogeneous_static_graph.nodes.data[_feature_key].numpy()
+            verb.append(gx.shape[1])
+            x = np.concatenate([x, gx], axis=1)
+            verbs.append(verb)
+            soft_timer.end()
+            if soft_timer.is_timeout():
+                break
+        if self._verbosity >= 1:
+            LOGGER.info(
+                tabulate.tabulate(verbs, headers="epoch origin after-gen after-sel".split())
+            )
+        homogeneous_static_graph.nodes.data[_feature_key] = torch.from_numpy(x)
+        return homogeneous_static_graph
+
+    def _transform(self, homogeneous_static_graph: autogl.data.graph.GeneralStaticGraph):
+        if not (
+                homogeneous_static_graph.nodes.is_homogeneous and
+                homogeneous_static_graph.edges.is_homogeneous
+        ):
+            raise ValueError
+        if 'x' in homogeneous_static_graph.nodes.data:
+            _feature_key = 'x'
+            _original_features: torch.Tensor = (
+                homogeneous_static_graph.nodes.data['x']
+            )
+        elif 'feat' in homogeneous_static_graph.nodes.data:
+            _feature_key = 'feat'
+            _original_features: torch.Tensor = (
+                homogeneous_static_graph.nodes.data['feat']
+            )
+        else:
+            raise ValueError
+
+        x: np.ndarray = _original_features.numpy()
+        gx: np.ndarray = x.copy()
+        for selection in self._selection:
+            gx = scale(self._gen(gx))[:, selection]
+            x = np.concatenate([x, gx], axis=1)
+        homogeneous_static_graph.nodes.data[_feature_key] = torch.from_numpy(x)
+        return homogeneous_static_graph

--- a/autogl/module/preprocessing/feature_engineering/_feature_engineer.py
+++ b/autogl/module/preprocessing/feature_engineering/_feature_engineer.py
@@ -1,0 +1,5 @@
+from .. import _data_preprocessor
+
+
+class FeatureEngineer(_data_preprocessor.DataPreprocessor):
+    ...

--- a/autogl/module/preprocessing/feature_engineering/_generators/__init__.py
+++ b/autogl/module/preprocessing/feature_engineering/_generators/__init__.py
@@ -1,0 +1,19 @@
+from ._basic import OneHotFeatureGenerator
+from ._eigen import EigenFeatureGenerator
+from ._graphlet import GraphletGenerator
+from ._page_rank import PageRankFeatureGenerator
+from ._pyg import (
+    LocalDegreeProfileGenerator,
+    NormalizeFeatures,
+    OneHotDegreeGenerator
+)
+
+__all__ = [
+    "OneHotFeatureGenerator",
+    "EigenFeatureGenerator",
+    "GraphletGenerator",
+    "PageRankFeatureGenerator",
+    "LocalDegreeProfileGenerator",
+    "NormalizeFeatures",
+    "OneHotDegreeGenerator"
+]

--- a/autogl/module/preprocessing/feature_engineering/_generators/_basic.py
+++ b/autogl/module/preprocessing/feature_engineering/_generators/_basic.py
@@ -1,0 +1,108 @@
+import torch
+import typing as _typing
+import autogl
+from autogl.data.graph import GeneralStaticGraph
+from .._feature_engineer import FeatureEngineer
+from ..._data_preprocessor_registry import DataPreprocessorUniversalRegistry
+
+
+class BaseFeatureGenerator(FeatureEngineer):
+    def __init__(self, override_features: bool = False):
+        super(BaseFeatureGenerator, self).__init__()
+        if not isinstance(override_features, bool):
+            raise TypeError
+        else:
+            self._override_features: bool = override_features
+
+    def _extract_nodes_feature(self, data: autogl.data.Data) -> torch.Tensor:
+        raise NotImplementedError
+
+    def __transform_homogeneous_static_graph(
+            self, homogeneous_static_graph: GeneralStaticGraph
+    ) -> GeneralStaticGraph:
+        if not (
+                homogeneous_static_graph.nodes.is_homogeneous and
+                homogeneous_static_graph.edges.is_homogeneous
+        ):
+            raise ValueError("Provided static graph must be homogeneous")
+        if 'x' in homogeneous_static_graph.nodes.data:
+            feature_key: _typing.Optional[str] = 'x'
+            features: _typing.Optional[torch.Tensor] = (
+                homogeneous_static_graph.nodes.data['x']
+            )
+        elif 'feat' in homogeneous_static_graph.nodes.data:
+            feature_key: _typing.Optional[str] = 'feat'
+            features: _typing.Optional[torch.Tensor] = (
+                homogeneous_static_graph.nodes.data['feat']
+            )
+        else:
+            feature_key: _typing.Optional[str] = None
+            features: _typing.Optional[torch.Tensor] = None
+        if 'y' in homogeneous_static_graph.nodes.data:
+            label: _typing.Optional[torch.Tensor] = (
+                homogeneous_static_graph.nodes.data['y']
+            )
+        elif 'label' in homogeneous_static_graph.nodes.data:
+            label: _typing.Optional[torch.Tensor] = (
+                homogeneous_static_graph.nodes.data['label']
+            )
+        else:
+            label: _typing.Optional[torch.Tensor] = None
+        if (
+                'edge_weight' in homogeneous_static_graph.edges.data and
+                homogeneous_static_graph.edges.data['edge_weight'].dim() == 1
+        ):
+            edge_weight: torch.Tensor = (
+                homogeneous_static_graph.edges.data['edge_weight']
+            )
+        else:
+            edge_weight: torch.Tensor = torch.ones(
+                homogeneous_static_graph.edges.connections.size(1)
+            )
+        data = autogl.data.Data(
+            edge_index=homogeneous_static_graph.edges.connections,
+            x=features, y=label
+        )
+        setattr(data, "edge_weight", edge_weight)
+        extracted_features: torch.Tensor = self._extract_nodes_feature(data)
+        if isinstance(feature_key, str):
+            nodes_features: torch.Tensor = (
+                homogeneous_static_graph.nodes.data[feature_key].view(-1, 1)
+                if homogeneous_static_graph.nodes.data[feature_key].dim() == 1
+                else homogeneous_static_graph.nodes.data[feature_key]
+            )
+            assert extracted_features.size(0) == nodes_features.size(0)
+            assert extracted_features.dim() == nodes_features.dim() == 2
+            homogeneous_static_graph.nodes.data[feature_key] = (
+                extracted_features.to(nodes_features.device)
+                if self._override_features
+                else torch.cat(
+                    [nodes_features, extracted_features.to(nodes_features.device)], dim=-1
+                )
+            )
+        else:
+            if autogl.backend.DependentBackend.is_pyg():
+                homogeneous_static_graph.nodes.data['x'] = extracted_features
+            elif autogl.backend.DependentBackend.is_dgl():
+                homogeneous_static_graph.nodes.data['feat'] = extracted_features
+        return homogeneous_static_graph
+
+    def _transform(
+            self, data: _typing.Union[GeneralStaticGraph, _typing.Any]
+    ) -> _typing.Union[GeneralStaticGraph, _typing.Any]:
+        if isinstance(data, GeneralStaticGraph):
+            return self.__transform_homogeneous_static_graph(data)
+        else:
+            data.x = self._extract_nodes_feature(data)
+            return data
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("OneHot".lower())
+class OneHotFeatureGenerator(BaseFeatureGenerator):
+    def _extract_nodes_feature(self, data: autogl.data.Data) -> torch.Tensor:
+        num_nodes: int = (
+            data.x.size(0)
+            if data.x is not None and isinstance(data.x, torch.Tensor)
+            else (data.edge_index.max().item() + 1)
+        )
+        return torch.eye(num_nodes)

--- a/autogl/module/preprocessing/feature_engineering/_generators/_eigen.py
+++ b/autogl/module/preprocessing/feature_engineering/_generators/_eigen.py
@@ -1,0 +1,88 @@
+import autogl
+import numpy as np
+from scipy.sparse import csr_matrix
+import scipy.sparse as ssp
+import scipy.sparse.linalg
+import networkx as nx
+import torch
+from ._basic import BaseFeatureGenerator
+from ..._data_preprocessor_registry import DataPreprocessorUniversalRegistry
+
+
+class _Eigen:
+    @classmethod
+    def __normalize_adj(cls, adj):
+        row_sum = np.array(adj.sum(1))
+        d_inv_sqrt = np.power(row_sum, -0.5).flatten()
+        d_inv_sqrt[np.isinf(d_inv_sqrt)] = 0.0
+        d_inv_sqrt = ssp.diags(d_inv_sqrt)
+        return adj.dot(d_inv_sqrt).transpose().dot(d_inv_sqrt)
+
+    def __call__(self, adj, d, use_eigenvalues=0, adj_norm=1):
+        G = nx.from_scipy_sparse_matrix(adj)
+        comp = list(nx.connected_components(G))
+        results = np.zeros((adj.shape[0], d))
+        for i in range(len(comp)):
+            node_index = np.array(list(comp[i]))
+            d_temp = min(len(node_index) - 2, d)
+            if d_temp <= 0:
+                continue
+            temp_adj = adj[node_index, :][:, node_index].asfptype()
+            if adj_norm == 1:
+                temp_adj = self.__normalize_adj(temp_adj)
+            lamb, X = scipy.sparse.linalg.eigs(temp_adj, d_temp)
+            lamb, X = lamb.real, X.real
+            temp_order = np.argsort(lamb)
+            lamb, X = lamb[temp_order], X[:, temp_order]
+            for i in range(X.shape[1]):
+                if np.sum(X[:, i]) < 0:
+                    X[:, i] = -X[:, i]
+            if use_eigenvalues == 1:
+                X = X.dot(np.diag(np.sqrt(np.absolute(lamb))))
+            elif use_eigenvalues == 2:
+                X = X.dot(np.diag(lamb))
+            results[node_index, :d_temp] = X
+        return results
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("eigen")
+class EigenFeatureGenerator(BaseFeatureGenerator):
+    r"""
+    concat Eigen features
+
+    Notes
+    -----
+    An implementation of [#]_
+
+    References
+    ----------
+    .. [#] Z. Zhang, P. Cui, J. Pei, X. Wang and W. Zhu,
+            "Eigen-GNN: a Graph Structure Preserving Plug-in for GNNs,"
+            in IEEE Transactions on Knowledge and Data Engineering, doi: 10.1109/TKDE.2021.3112746.
+
+    Parameters
+    ----------
+    size : int
+        EigenGNN hidden size
+    """
+    def __init__(self, size: int = 32):
+        super(EigenFeatureGenerator, self).__init__()
+        self.__size: int = size
+
+    def _extract_nodes_feature(self, data: autogl.data.Data) -> torch.Tensor:
+        edge_index: np.ndarray = data.edge_index.numpy()
+        edge_weight: np.ndarray = getattr(data, "edge_weight").numpy()
+        num_nodes: int = (
+            data.x.size(0)
+            if data.x is not None and isinstance(data.x, torch.Tensor)
+            else (data.edge_index.max().item() + 1)
+        )
+        adj = csr_matrix(
+            (edge_weight, (edge_index[0, :], edge_index[1, :])),
+            shape=(num_nodes, num_nodes)
+        )
+        if np.max(adj - adj.T) > 1e-5:
+            adj = adj + adj.T
+        mf = _Eigen()
+        features: np.ndarray = mf(adj, self.__size)
+        return torch.from_numpy(features)

--- a/autogl/module/preprocessing/feature_engineering/_generators/_graphlet.py
+++ b/autogl/module/preprocessing/feature_engineering/_generators/_graphlet.py
@@ -1,0 +1,247 @@
+import logging
+import numpy as np
+import torch
+from tqdm import tqdm
+import autogl
+from ._basic import BaseFeatureGenerator
+from ..._data_preprocessor_registry import DataPreprocessorUniversalRegistry
+
+_LOGGER = logging.getLogger("FE")
+
+
+class _Graphlet:
+    def __init__(self, data, sample_error=0.1, sample_confidence=0.1):
+        self._data = data
+        self._init()
+
+        self._sample_error = sample_error
+        self._sample_confidence = sample_confidence
+        self._dw = int(
+            np.ceil(
+                0.5 * (self._sample_error ** -2) * np.log(2 / self._sample_confidence)
+            )
+        )
+        _LOGGER.info(
+            "sample error {} , confidence {},num {}".format(
+                self._sample_error, self._sample_confidence, self._dw
+            )
+        )
+
+    def _init(self):
+        self._edges = list(self._data.edge_index)
+        self._edges = [self._edges[0], self._edges[1]]
+        self._num_nodes = self._data.x.shape[0]
+        self._num_edges = len(self._edges[0])
+        self._neighbours = [[] for _ in range(self._num_nodes)]
+        for i in range(len(self._edges[0])):
+            u, v = self._edges[0][i], self._edges[1][i]
+            self._neighbours[u].append(v)
+
+        _LOGGER.info("nodes {} , edges {}".format(self._num_nodes, self._num_edges))
+
+        # sorting
+        self._node_degrees = np.array([len(x) for x in self._neighbours])
+        self._nodes = np.argsort(self._node_degrees)
+        for i in self._nodes:
+            self._neighbours[i] = [
+                x
+                for _, x in sorted(
+                    zip(self._node_degrees[self._neighbours[i]], self._neighbours[i]),
+                    reverse=True,
+                )
+            ]
+        self._neighbours = [np.array(x) for x in self._neighbours]
+
+    def _get_gdv(self, v, u):
+        if self._node_degrees[v] >= self._node_degrees[u]:
+            pass
+        else:
+            u, v = v, u
+        Sv, Su, Te = set(), set(), set()
+        sigma1, sigma2 = 0, 0
+        nb = self._neighbours
+        N = self._num_nodes
+        M = self._num_edges
+        phi = np.zeros(self._num_nodes, dtype=int)
+        c1, c2, c3, c4 = 1, 2, 3, 4
+        x = np.zeros(16, dtype=int)
+        # p1
+        for w in nb[v]:
+            if w != u:
+                Sv.add(w)
+                phi[w] = c1
+        # p2
+        for w in nb[u]:
+            if w != v:
+                if phi[w] == c1:
+                    Te.add(w)
+                    phi[w] = c3
+                    Sv.remove(w)
+                else:
+                    Su.add(w)
+                    phi[w] = c2
+        # p3
+        for w in Te:
+            for r in nb[w]:
+                if phi[r] == c3:
+                    x[5] += 1
+            phi[w] = c4
+            sigma2 = sigma2 + len(nb[w]) - 2
+        # p4
+        for w in Su:
+            for r in nb[w]:
+                if phi[r] == c1:
+                    x[8] += 1
+                if phi[r] == c2:
+                    x[7] += 1
+                if phi[r] == c4:
+                    sigma1 += 1
+            phi[w] = 0
+            sigma2 = sigma2 + len(nb[w]) - 1
+        # p5
+        for w in Sv:
+            for r in nb[w]:
+                if phi[r] == c1:
+                    x[7] += 1
+                if phi[r] == c4:
+                    sigma1 += 1
+            phi[w] = 0
+            sigma2 = sigma2 + len(nb[w]) - 1
+
+        lsv, lsu, lte, du, dv = len(Sv), len(Su), len(Te), len(nb[u]), len(nb[v])
+        # 3-graphlet
+        x[1] = lte
+        x[2] = du + dv - 2 - 2 * x[1]
+        x[3] = N - x[2] - x[1] - 2
+        x[4] = N * (N - 1) * (N - 2) / 6 - (x[1] + x[2] + x[3])
+        # 4 connected graphlets
+        x[6] = x[1] * (x[1] - 1) / 2 - x[5]
+        x[10] = lsv * lsu - x[8]
+        x[9] = lsv * (lsv - 1) / 2 + lsu * (lsu - 1) / 2 - x[7]
+        # 4 disconnected graphlets
+        t1 = N - (lte + lsu + lsv + 2)
+        x[11] = x[1] * t1
+        x[12] = M - (du + dv - 1) - (sigma2 - sigma1 - x[5] - x[8] - x[7])
+        x[13] = (lsu + lsv) * t1
+        x[14] = t1 * (t1 - 1) / 2 - x[12]
+        x[15] = N * (N - 1) * (N - 2) * (N - 3) / 24 - np.sum(x[5:15])
+
+        return x
+
+    def _get_gdv_sample(self, v, u):
+        if self._node_degrees[v] >= self._node_degrees[u]:
+            pass
+        else:
+            u, v = v, u
+        Sv = set()
+        sigma1, sigma2 = 0, 0
+        nb = self._neighbours
+        N = self._num_nodes
+        M = self._num_edges
+        phi = np.zeros(self._num_nodes, dtype=int)
+        c1, c2, c3, c4 = 1, 2, 3, 4
+        x = np.zeros(16)
+        dw = self._dw
+
+        # p1
+        Sv = set(nb[v][nb[v] != u])
+        phi[list(Sv)] = c1
+        # p2
+        p2w = nb[u][nb[u] != c1]
+        p2w1 = p2w[phi[p2w] == c1]
+        p2w2 = p2w[phi[p2w] != c1]
+        Te = p2w1
+        phi[p2w1] = c3
+        Sv -= set(list(p2w1))
+        Su = p2w2
+        phi[p2w2] = c2
+        # p3
+        for w in Te:
+            if dw >= len(nb[w]):
+                region = nb[w]
+                inc = 1
+            else:
+                region = np.random.choice(nb[w], dw, replace=False)
+                inc = self._node_degrees[w] / dw
+            phir = phi[region]
+            x[5] += inc * np.sum(phir == c3)
+            phi[w] = c4
+            sigma2 = sigma2 + len(nb[w]) - 2
+        # p4
+        for w in Su:
+            if dw >= len(nb[w]):
+                region = nb[w]
+                inc = 1
+            else:
+                region = np.random.choice(nb[w], dw, replace=False)
+                inc = self._node_degrees[w] / dw
+            phir = phi[region]
+            x[8] += inc * np.sum(phir == c1)
+            x[7] += inc * np.sum(phir == c2)
+            sigma1 += inc * np.sum(phir == c4)
+            phi[w] = 0
+            sigma2 = sigma2 + len(nb[w]) - 1
+        # p5
+        for w in Sv:
+            if dw >= len(nb[w]):
+                region = nb[w]
+                inc = 1
+            else:
+                region = np.random.choice(nb[w], dw, replace=False)
+                inc = self._node_degrees[w] / dw
+            phir = phi[region]
+            x[7] += inc * np.sum(phir == c1)
+            sigma1 += inc * np.sum(phir == c4)
+            phi[w] = 0
+            sigma2 = sigma2 + len(nb[w]) - 1
+
+        lsv, lsu, lte, du, dv = len(Sv), len(Su), len(Te), len(nb[u]), len(nb[v])
+        # 3-graphlet
+        x[1] = lte
+        x[2] = du + dv - 2 - 2 * x[1]
+        x[3] = N - x[2] - x[1] - 2
+        x[4] = N * (N - 1) * (N - 2) / 6 - (x[1] + x[2] + x[3])
+        # 4 connected graphlets
+        x[6] = x[1] * (x[1] - 1) / 2 - x[5]
+        x[10] = lsv * lsu - x[8]
+        x[9] = lsv * (lsv - 1) / 2 + lsu * (lsu - 1) / 2 - x[7]
+        # 4 disconnected graphlets
+        t1 = N - (lte + lsu + lsv + 2)
+        x[11] = x[1] * t1
+        x[12] = M - (du + dv - 1) - (sigma2 - sigma1 - x[5] - x[8] - x[7])
+        x[13] = (lsu + lsv) * t1
+        x[14] = t1 * (t1 - 1) / 2 - x[12]
+        x[15] = N * (N - 1) * (N - 2) * (N - 3) / 24 - np.sum(x[5:15])
+
+        return x
+
+    def get_gdvs(self, sample=True):
+        res = np.zeros((self._num_nodes, 15))
+        for u in tqdm(range(self._num_nodes)):
+            vs = self._neighbours[u]
+            if len(vs) != 0:
+                gdvs = []
+                for v in tqdm(vs, disable=len(vs) < 100):
+                    if sample:
+                        gdvs.append(self._get_gdv_sample(u, v))
+                    else:
+                        gdvs.append(self._get_gdv(u, v))
+                res[u, :] = np.mean(gdvs, axis=0)[1:]
+        return res
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("graph" + "let")
+class GraphletGenerator(BaseFeatureGenerator):
+    r"""generate local graphlet numbers as features. The implementation refers to [#]_ .
+
+    References
+    ----------
+    .. [#] Ahmed, N. K., Willke, T. L., & Rossi, R. A. (2016).
+        Estimation of local subgraph counts. Proceedings - 2016 IEEE International Conference on Big Data, Big Data 2016, 586–595.
+        https://doi.org/10.1109/BigData.2016.7840651
+
+    """
+
+    def _extract_nodes_feature(self, data: autogl.data.Data) -> torch.Tensor:
+        result: np.ndarray = _Graphlet(data).get_gdvs()
+        return torch.from_numpy(result)

--- a/autogl/module/preprocessing/feature_engineering/_generators/_page_rank.py
+++ b/autogl/module/preprocessing/feature_engineering/_generators/_page_rank.py
@@ -1,0 +1,29 @@
+import numpy as np
+import networkx as nx
+import torch
+import autogl
+from ._basic import BaseFeatureGenerator
+from ..._data_preprocessor_registry import DataPreprocessorUniversalRegistry
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("PageRank".lower())
+class PageRankFeatureGenerator(BaseFeatureGenerator):
+    def _extract_nodes_feature(self, data: autogl.data.Data) -> torch.Tensor:
+        edge_weight = getattr(data, "edge_weight").tolist()
+        g = nx.DiGraph()
+        g.add_weighted_edges_from(
+            [
+                (u, v, edge_weight[i])
+                for i, (u, v) in enumerate(data.edge_index.t().tolist())
+            ]
+        )
+        page_rank = nx.pagerank(g)
+        num_nodes: int = (
+            data.x.size(0)
+            if data.x is not None and isinstance(data.x, torch.Tensor)
+            else (data.edge_index.max().item() + 1)
+        )
+        pr = np.zeros(num_nodes)
+        for i, v in page_rank.items():
+            pr[i] = v
+        return torch.from_numpy(pr)

--- a/autogl/module/preprocessing/feature_engineering/_generators/_pyg.py
+++ b/autogl/module/preprocessing/feature_engineering/_generators/_pyg.py
@@ -1,0 +1,82 @@
+import torch.nn.functional
+import autogl
+from ._basic import BaseFeatureGenerator
+from ._pyg_impl import degree, scatter_min, scatter_max, scatter_mean, scatter_std
+from ..._data_preprocessor_registry import DataPreprocessorUniversalRegistry
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("LocalDegreeProfile")
+class LocalDegreeProfileGenerator(BaseFeatureGenerator):
+    r"""Appends the Local Degree Profile (LDP) from the `"A Simple yet
+    Effective Baseline for Non-attribute Graph Classification"
+    <https://arxiv.org/abs/1811.03508>`_ paper
+
+    .. math::
+        \mathbf{x}_i = \mathbf{x}_i \, \Vert \, (\deg(i), \min(DN(i)),
+        \max(DN(i)), \textrm{mean}(DN(i)), \textrm{std}(DN(i)))
+
+    to the node features, where :math:`DN(i) = \{ \deg(j) \mid j \in
+    \mathcal{N}(i) \}`.
+    """
+
+    def _extract_nodes_feature(self, data: autogl.data.Data) -> torch.Tensor:
+        row, col = data.edge_index
+        if data.x is not None and isinstance(data.x, torch.Tensor):
+            N = data.x.size(0)
+        else:
+            N = (torch.max(data.edge_index).item() + 1)
+
+        deg = degree(row, N, dtype=torch.float)
+        deg_col = deg[col]
+
+        min_deg, _ = scatter_min(deg_col, row, dim_size=N)
+        min_deg[min_deg > 10000] = 0
+        max_deg, _ = scatter_max(deg_col, row, dim_size=N)
+        max_deg[max_deg < -10000] = 0
+        mean_deg = scatter_mean(deg_col, row, dim_size=N)
+        std_deg = scatter_std(deg_col, row, dim_size=N)
+
+        x = torch.stack([deg, min_deg, max_deg, mean_deg, std_deg], dim=1)
+        return x
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NormalizeFeatures")
+class NormalizeFeatures(BaseFeatureGenerator):
+    def __init__(self):
+        super(NormalizeFeatures, self).__init__(override_features=True)
+
+    def _extract_nodes_feature(self, data: autogl.data.Data) -> torch.Tensor:
+        if data.x is not None and isinstance(data.x, torch.Tensor):
+            data.x.div_(data.x.sum(dim=-1, keepdim=True).clamp_(min=1.))
+        return data.x
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("OneHotDegree")
+class OneHotDegreeGenerator(BaseFeatureGenerator):
+    r"""Adds the node degree as one hot encodings to the node features.
+
+    Args:
+        max_degree (int): Maximum degree.
+        in_degree (bool, optional): If set to :obj:`True`, will compute the
+            in-degree of nodes instead of the out-degree.
+            (default: :obj:`False`)
+        cat (bool, optional): Concat node degrees to node features instead
+            of replacing them. (default: :obj:`True`)
+    """
+
+    def __init__(
+            self, max_degree: int = 1000,
+            in_degree: bool = False, cat: bool = True
+    ):
+        self.__max_degree: int = max_degree
+        self.__in_degree: bool = in_degree
+        self.__cat: bool = cat
+        super(OneHotDegreeGenerator, self).__init__()
+
+    def _extract_nodes_feature(self, data: autogl.data.Data) -> torch.Tensor:
+        idx, x = data.edge_index[1 if self.__in_degree else 0], data.x
+        deg = degree(idx, data.num_nodes, dtype=torch.long)
+        deg = torch.nn.functional.one_hot(
+            deg, num_classes=self.__max_degree + 1
+        ).to(torch.float)
+        return deg

--- a/autogl/module/preprocessing/feature_engineering/_generators/_pyg_impl.py
+++ b/autogl/module/preprocessing/feature_engineering/_generators/_pyg_impl.py
@@ -1,0 +1,234 @@
+import torch
+import typing as _typing
+from typing import Optional, Tuple
+
+
+def degree(index, num_nodes: _typing.Optional[int] = None,
+           dtype: _typing.Optional[torch.dtype] = None):
+    r"""Computes the (unweighted) degree of a given one-dimensional index
+    tensor.
+
+    Args:
+        index (LongTensor): Index tensor.
+        num_nodes (int, optional): The number of nodes, *i.e.*
+            :obj:`max_val + 1` of :attr:`index`. (default: :obj:`None`)
+        dtype (:obj:`torch.dtype`, optional): The desired data type of the
+            returned tensor.
+
+    :rtype: :class:`Tensor`
+    """
+
+    def maybe_num_nodes(edge_index, __num_nodes=None):
+        if __num_nodes is not None:
+            return __num_nodes
+        elif isinstance(edge_index, torch.Tensor):
+            return int(edge_index.max()) + 1 if edge_index.numel() > 0 else 0
+        else:
+            return max(edge_index.size(0), edge_index.size(1))
+
+    N = maybe_num_nodes(index, num_nodes)
+    out = torch.zeros((N,), dtype=dtype, device=index.device)
+    one = torch.ones((index.size(0),), dtype=out.dtype, device=out.device)
+    return out.scatter_add_(0, index, one)
+
+
+def broadcast(src: torch.Tensor, other: torch.Tensor, dim: int):
+    if dim < 0:
+        dim = other.dim() + dim
+    if src.dim() == 1:
+        for _ in range(0, dim):
+            src = src.unsqueeze(0)
+    for _ in range(src.dim(), other.dim()):
+        src = src.unsqueeze(-1)
+    src = src.expand_as(other)
+    return src
+
+
+def scatter_sum(src: torch.Tensor, index: torch.Tensor, dim: int = -1,
+                out: Optional[torch.Tensor] = None,
+                dim_size: Optional[int] = None) -> torch.Tensor:
+    index = broadcast(index, src, dim)
+    if out is None:
+        size = list(src.size())
+        if dim_size is not None:
+            size[dim] = dim_size
+        elif index.numel() == 0:
+            size[dim] = 0
+        else:
+            size[dim] = int(index.max()) + 1
+        out = torch.zeros(size, dtype=src.dtype, device=src.device)
+        return out.scatter_add_(dim, index, src)
+    else:
+        return out.scatter_add_(dim, index, src)
+
+
+def scatter_add(src: torch.Tensor, index: torch.Tensor, dim: int = -1,
+                out: Optional[torch.Tensor] = None,
+                dim_size: Optional[int] = None) -> torch.Tensor:
+    return scatter_sum(src, index, dim, out, dim_size)
+
+
+def scatter_mul(src: torch.Tensor, index: torch.Tensor, dim: int = -1,
+                out: Optional[torch.Tensor] = None,
+                dim_size: Optional[int] = None) -> torch.Tensor:
+    return torch.ops.torch_scatter.scatter_mul(src, index, dim, out, dim_size)
+
+
+def scatter_mean(src: torch.Tensor, index: torch.Tensor, dim: int = -1,
+                 out: Optional[torch.Tensor] = None,
+                 dim_size: Optional[int] = None) -> torch.Tensor:
+    out = scatter_sum(src, index, dim, out, dim_size)
+    dim_size = out.size(dim)
+
+    index_dim = dim
+    if index_dim < 0:
+        index_dim = index_dim + src.dim()
+    if index.dim() <= index_dim:
+        index_dim = index.dim() - 1
+
+    ones = torch.ones(index.size(), dtype=src.dtype, device=src.device)
+    count = scatter_sum(ones, index, index_dim, None, dim_size)
+    count[count < 1] = 1
+    count = broadcast(count, out, dim)
+    if out.is_floating_point():
+        out.true_divide_(count)
+    else:
+        out.floor_divide_(count)
+    return out
+
+
+def scatter_min(
+        src: torch.Tensor, index: torch.Tensor, dim: int = -1,
+        out: Optional[torch.Tensor] = None,
+        dim_size: Optional[int] = None) -> Tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.torch_scatter.scatter_min(src, index, dim, out, dim_size)
+
+
+def scatter_max(
+        src: torch.Tensor, index: torch.Tensor, dim: int = -1,
+        out: Optional[torch.Tensor] = None,
+        dim_size: Optional[int] = None) -> Tuple[torch.Tensor, torch.Tensor]:
+    return torch.ops.torch_scatter.scatter_max(src, index, dim, out, dim_size)
+
+
+def scatter_std(src: torch.Tensor, index: torch.Tensor, dim: int = -1,
+                out: Optional[torch.Tensor] = None,
+                dim_size: Optional[int] = None,
+                unbiased: bool = True) -> torch.Tensor:
+    if out is not None:
+        dim_size = out.size(dim)
+
+    if dim < 0:
+        dim = src.dim() + dim
+
+    count_dim = dim
+    if index.dim() <= dim:
+        count_dim = index.dim() - 1
+
+    ones = torch.ones(index.size(), dtype=src.dtype, device=src.device)
+    count = scatter_sum(ones, index, count_dim, dim_size=dim_size)
+
+    index = broadcast(index, src, dim)
+    tmp = scatter_sum(src, index, dim, dim_size=dim_size)
+    count = broadcast(count, tmp, dim).clamp(1)
+    mean = tmp.div(count)
+
+    var = (src - mean.gather(dim, index))
+    var = var * var
+    out = scatter_sum(var, index, dim, out, dim_size)
+
+    if unbiased:
+        count = count.sub(1).clamp_(1)
+    out = out.div(count + 1e-6).sqrt()
+
+    return out
+
+
+def scatter(src: torch.Tensor, index: torch.Tensor, dim: int = -1,
+            out: Optional[torch.Tensor] = None, dim_size: Optional[int] = None,
+            reduce: str = "sum") -> torch.Tensor:
+    r"""
+    |
+
+    .. image:: https://raw.githubusercontent.com/rusty1s/pytorch_scatter/
+            master/docs/source/_figures/add.svg?sanitize=true
+        :align: center
+        :width: 400px
+
+    |
+
+    Reduces all values from the :attr:`src` tensor into :attr:`out` at the
+    indices specified in the :attr:`index` tensor along a given axis
+    :attr:`dim`.
+    For each value in :attr:`src`, its output index is specified by its index
+    in :attr:`src` for dimensions outside of :attr:`dim` and by the
+    corresponding value in :attr:`index` for dimension :attr:`dim`.
+    The applied reduction is defined via the :attr:`reduce` argument.
+
+    Formally, if :attr:`src` and :attr:`index` are :math:`n`-dimensional
+    tensors with size :math:`(x_0, ..., x_{i-1}, x_i, x_{i+1}, ..., x_{n-1})`
+    and :attr:`dim` = `i`, then :attr:`out` must be an :math:`n`-dimensional
+    tensor with size :math:`(x_0, ..., x_{i-1}, y, x_{i+1}, ..., x_{n-1})`.
+    Moreover, the values of :attr:`index` must be between :math:`0` and
+    :math:`y - 1`, although no specific ordering of indices is required.
+    The :attr:`index` tensor supports broadcasting in case its dimensions do
+    not match with :attr:`src`.
+
+    For one-dimensional tensors with :obj:`reduce="sum"`, the operation
+    computes
+
+    .. math::
+        \mathrm{out}_i = \mathrm{out}_i + \sum_j~\mathrm{src}_j
+
+    where :math:`\sum_j` is over :math:`j` such that
+    :math:`\mathrm{index}_j = i`.
+
+    .. note::
+
+        This operation is implemented via atomic operations on the GPU and is
+        therefore **non-deterministic** since the order of parallel operations
+        to the same value is undetermined.
+        For floating-point variables, this results in a source of variance in
+        the result.
+
+    :param src: The source tensor.
+    :param index: The indices of elements to scatter.
+    :param dim: The axis along which to index. (default: :obj:`-1`)
+    :param out: The destination tensor.
+    :param dim_size: If :attr:`out` is not given, automatically create output
+        with size :attr:`dim_size` at dimension :attr:`dim`.
+        If :attr:`dim_size` is not given, a minimal sized output tensor
+        according to :obj:`index.max() + 1` is returned.
+    :param reduce: The reduce operation (:obj:`"sum"`, :obj:`"mul"`,
+        :obj:`"mean"`, :obj:`"min"` or :obj:`"max"`). (default: :obj:`"sum"`)
+
+    :rtype: :class:`Tensor`
+
+    .. code-block:: python
+
+        from torch_scatter import scatter
+
+        src = torch.randn(10, 6, 64)
+        index = torch.tensor([0, 1, 0, 1, 2, 1])
+
+        # Broadcasting in the first and last dim.
+        out = scatter(src, index, dim=1, reduce="sum")
+
+        print(out.size())
+
+    .. code-block::
+
+        torch.Size([10, 3, 64])
+    """
+    if reduce == 'sum' or reduce == 'add':
+        return scatter_sum(src, index, dim, out, dim_size)
+    if reduce == 'mul':
+        return scatter_mul(src, index, dim, out, dim_size)
+    elif reduce == 'mean':
+        return scatter_mean(src, index, dim, out, dim_size)
+    elif reduce == 'min':
+        return scatter_min(src, index, dim, out, dim_size)[0]
+    elif reduce == 'max':
+        return scatter_max(src, index, dim, out, dim_size)[0]
+    else:
+        raise ValueError

--- a/autogl/module/preprocessing/feature_engineering/_graph/__init__.py
+++ b/autogl/module/preprocessing/feature_engineering/_graph/__init__.py
@@ -1,0 +1,17 @@
+from ._netlsd import NetLSD
+from ._networkx import (
+    NXLargeCliqueSize,
+    NXDegreeAssortativityCoefficient,
+    NXDegreePearsonCorrelationCoefficient,
+    NXHasBridges,
+    NXGraphCliqueNumber,
+    NXGraphNumberOfCliques,
+    NXTransitivity,
+    NXAverageClustering,
+    NXIsConnected,
+    NXNumberConnectedComponents,
+    NXIsDistanceRegular,
+    NXLocalEfficiency,
+    NXGlobalEfficiency,
+    NXIsEulerian,
+)

--- a/autogl/module/preprocessing/feature_engineering/_graph/_netlsd.py
+++ b/autogl/module/preprocessing/feature_engineering/_graph/_netlsd.py
@@ -1,0 +1,85 @@
+import netlsd
+import networkx
+import torch
+import typing
+from autogl.data.graph import GeneralStaticGraph
+from autogl.data.graph.utils import conversion
+from .._feature_engineer import FeatureEngineer
+from ..._data_preprocessor_registry import DataPreprocessorUniversalRegistry
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NetLSD".lower())
+class NetLSD(FeatureEngineer):
+    r"""
+    Notes
+    -----
+    a graph feature generation method. This is a simple wrapper of NetLSD [#]_.
+
+    References
+    ----------
+    ..  [#] A. Tsitsulin, D. Mottin, P. Karras, A. Bronstein, and E. Müller, “NetLSD: Hearing the shape of a graph,”
+        Proc. ACM SIGKDD Int. Conf. Knowl. Discov. Data Min., pp. 2347–2356, 2018.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.__args = args
+        self.__kwargs = kwargs
+        super(NetLSD, self).__init__()
+
+    def __extract(self, nx_g: networkx.Graph) -> torch.Tensor:
+        return torch.tensor(netlsd.heat(nx_g, *self.__args, **self.__kwargs)).view(-1)
+
+    def __transform_homogeneous_static_graph(
+            self, homogeneous_static_graph: GeneralStaticGraph
+    ) -> GeneralStaticGraph:
+        if not (
+                homogeneous_static_graph.nodes.is_homogeneous and
+                homogeneous_static_graph.edges.is_homogeneous
+        ):
+            raise ValueError("Provided static graph must be homogeneous")
+        dsc: torch.Tensor = self.__extract(
+            conversion.HomogeneousStaticGraphToNetworkX(to_undirected=True).__call__(
+                homogeneous_static_graph, to_undirected=True
+            )
+        )
+        if 'gf' in homogeneous_static_graph.data:
+            gf = homogeneous_static_graph.data['gf'].view(-1)
+            homogeneous_static_graph.data['gf'] = torch.cat([gf, dsc])
+        else:
+            homogeneous_static_graph.data['gf'] = dsc
+        return homogeneous_static_graph
+
+    @classmethod
+    def __edge_index_to_nx_graph(cls, edge_index: torch.Tensor) -> networkx.Graph:
+        g: networkx.Graph = networkx.Graph()
+        for u, v in edge_index.t().tolist():
+            if u == v:
+                continue
+            else:
+                g.add_edge(u, v)
+        return g
+
+    def __transform_data(self, data):
+        if not (
+                hasattr(data, "edge_index") and
+                torch.is_tensor(data.edge_index) and
+                isinstance(data.edge_index, torch.Tensor) and
+                data.edge_index.dim() == data.edge_index.size(0) == 2 and
+                data.edge_index.dtype == torch.long
+        ):
+            raise TypeError("Unsupported provided data")
+        dsc: torch.Tensor = self.__extract(self.__edge_index_to_nx_graph(data.edge_index))
+        if hasattr(data, 'gf') and isinstance(data.gf, torch.Tensor):
+            gf = data.gf.view(-1)
+            data.gf = torch.cat([gf, dsc])
+        else:
+            data.gf = dsc
+        return data
+
+    def _transform(
+            self, data: typing.Union[GeneralStaticGraph, typing.Any]
+    ) -> typing.Union[GeneralStaticGraph, typing.Any]:
+        if isinstance(data, GeneralStaticGraph):
+            return self.__transform_homogeneous_static_graph(data)
+        else:
+            return self.__transform_data(data)

--- a/autogl/module/preprocessing/feature_engineering/_graph/_networkx.py
+++ b/autogl/module/preprocessing/feature_engineering/_graph/_networkx.py
@@ -1,0 +1,178 @@
+import torch
+import typing as _typing
+import networkx
+from networkx.algorithms.euler import is_eulerian
+from networkx.algorithms.efficiency_measures import global_efficiency
+from networkx.algorithms.efficiency_measures import local_efficiency
+from networkx.algorithms.distance_regular import is_distance_regular
+from networkx.algorithms.components import number_connected_components
+from networkx.algorithms.components import is_connected
+# from networkx.algorithms.cluster import average_clustering
+from networkx.algorithms.cluster import transitivity
+from networkx.algorithms.clique import graph_number_of_cliques
+from networkx.algorithms.clique import graph_clique_number
+from networkx.algorithms.bridges import has_bridges
+from networkx.algorithms.assortativity import degree_pearson_correlation_coefficient
+from networkx.algorithms.assortativity import degree_assortativity_coefficient
+from networkx.algorithms.approximation.clustering_coefficient import average_clustering
+from networkx.algorithms.approximation.clique import large_clique_size
+
+from autogl.data.graph import GeneralStaticGraph
+from autogl.data.graph.utils import conversion
+from .._feature_engineer import FeatureEngineer
+from ..._data_preprocessor_registry import DataPreprocessorUniversalRegistry
+
+
+class _NetworkXGraphFeatureEngineer(FeatureEngineer):
+    def __init__(self, feature_extractor: _typing.Callable[[networkx.Graph], _typing.Any]):
+        self.__feature_extractor: _typing.Callable[[networkx.Graph], _typing.Any] = feature_extractor
+        super(_NetworkXGraphFeatureEngineer, self).__init__()
+
+    def __transform_homogeneous_static_graph(
+            self, homogeneous_static_graph: GeneralStaticGraph
+    ) -> GeneralStaticGraph:
+        if not (
+                homogeneous_static_graph.nodes.is_homogeneous and
+                homogeneous_static_graph.edges.is_homogeneous
+        ):
+            raise ValueError("Provided static graph must be homogeneous")
+        dsc: torch.Tensor = torch.tensor(
+            [
+                self.__feature_extractor(
+                    conversion.HomogeneousStaticGraphToNetworkX(to_undirected=True)(homogeneous_static_graph)
+                )
+            ]
+        ).view(-1)
+        if 'gf' in homogeneous_static_graph.data:
+            gf = homogeneous_static_graph.data['gf'].view(-1)
+            homogeneous_static_graph.data['gf'] = torch.cat([gf, dsc])
+        else:
+            homogeneous_static_graph.data['gf'] = dsc
+        return homogeneous_static_graph
+
+    @classmethod
+    def __edge_index_to_nx_graph(cls, edge_index: torch.Tensor) -> networkx.Graph:
+        g: networkx.Graph = networkx.Graph()
+        for u, v in edge_index.t().tolist():
+            if u == v:
+                continue
+            else:
+                g.add_edge(u, v)
+        return g
+
+    def __transform_data(self, data):
+        if not (
+                hasattr(data, "edge_index") and
+                torch.is_tensor(data.edge_index) and
+                isinstance(data.edge_index, torch.Tensor) and
+                data.edge_index.dim() == data.edge_index.size(0) == 2 and
+                data.edge_index.dtype == torch.long
+        ):
+            raise TypeError("Unsupported provided data")
+        dsc: torch.Tensor = torch.tensor(
+            [self.__feature_extractor(self.__edge_index_to_nx_graph(data.edge_index))]
+        ).view(-1)
+        if hasattr(data, 'gf') and isinstance(data.gf, torch.Tensor):
+            gf = data.gf.view(-1)
+            data.gf = torch.cat([gf, dsc])
+        else:
+            data.gf = dsc
+        return data
+
+    def _transform(
+            self, data: _typing.Union[GeneralStaticGraph, _typing.Any]
+    ) -> _typing.Union[GeneralStaticGraph, _typing.Any]:
+        if isinstance(data, GeneralStaticGraph):
+            return self.__transform_homogeneous_static_graph(data)
+        else:
+            return self.__transform_data(data)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXLargeCliqueSize")
+class NXLargeCliqueSize(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXLargeCliqueSize, self).__init__(large_clique_size)
+
+
+# @FeatureEngineerUniversalRegistry.register_feature_engineer("NXAverageClusteringApproximate")
+# class NXAverageClusteringApproximate(_NetworkXGraphFeatureEngineer):
+#     def __init__(self):
+#         super(NXAverageClusteringApproximate, self).__init__(average_clustering)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXDegreeAssortativityCoefficient")
+class NXDegreeAssortativityCoefficient(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXDegreeAssortativityCoefficient, self).__init__(degree_assortativity_coefficient)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXDegreePearsonCorrelationCoefficient")
+class NXDegreePearsonCorrelationCoefficient(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXDegreePearsonCorrelationCoefficient, self).__init__(degree_pearson_correlation_coefficient)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXHasBridges")
+class NXHasBridges(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXHasBridges, self).__init__(has_bridges)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXGraphCliqueNumber")
+class NXGraphCliqueNumber(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXGraphCliqueNumber, self).__init__(graph_clique_number)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXGraphNumberOfCliques")
+class NXGraphNumberOfCliques(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXGraphNumberOfCliques, self).__init__(graph_number_of_cliques)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXTransitivity")
+class NXTransitivity(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXTransitivity, self).__init__(transitivity)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXAverageClustering")
+class NXAverageClustering(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXAverageClustering, self).__init__(average_clustering)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXIsConnected")
+class NXIsConnected(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXIsConnected, self).__init__(is_connected)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXNumberConnectedComponents")
+class NXNumberConnectedComponents(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXNumberConnectedComponents, self).__init__(number_connected_components)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXIsDistanceRegular")
+class NXIsDistanceRegular(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXIsDistanceRegular, self).__init__(is_distance_regular)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXLocalEfficiency")
+class NXLocalEfficiency(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXLocalEfficiency, self).__init__(local_efficiency)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXGlobalEfficiency")
+class NXGlobalEfficiency(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXGlobalEfficiency, self).__init__(global_efficiency)
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("NXIsEulerian")
+class NXIsEulerian(_NetworkXGraphFeatureEngineer):
+    def __init__(self):
+        super(NXIsEulerian, self).__init__(is_eulerian)

--- a/autogl/module/preprocessing/feature_engineering/_selectors/__init__.py
+++ b/autogl/module/preprocessing/feature_engineering/_selectors/__init__.py
@@ -1,0 +1,2 @@
+from ._basic import FilterConstant
+from ._gbdt import GBDTFeatureSelector

--- a/autogl/module/preprocessing/feature_engineering/_selectors/_basic.py
+++ b/autogl/module/preprocessing/feature_engineering/_selectors/_basic.py
@@ -1,0 +1,72 @@
+import numpy as np
+import torch
+import typing
+import autogl.data.graph
+from .._feature_engineer import FeatureEngineer
+from ..._data_preprocessor_registry import DataPreprocessorUniversalRegistry
+
+
+class BaseFeatureSelector(FeatureEngineer):
+    def __init__(self):
+        super(BaseFeatureSelector, self).__init__()
+        self._selection: typing.Optional[torch.Tensor] = None
+
+    def __transform_homogeneous_static_graph(
+            self, static_graph: autogl.data.graph.GeneralStaticGraph
+    ) -> autogl.data.graph.GeneralStaticGraph:
+        if (
+                'x' in static_graph.nodes.data and
+                isinstance(self._selection, (torch.Tensor, np.ndarray))
+        ):
+            static_graph.nodes.data['x'] = static_graph.nodes.data['x'][:, self._selection]
+        if (
+                'feat' in static_graph.nodes.data and
+                isinstance(self._selection, (torch.Tensor, np.ndarray))
+        ):
+            static_graph.nodes.data['feat'] = static_graph.nodes.data['feat'][:, self._selection]
+        return static_graph
+
+    def _transform(
+            self, data: typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]
+    ) -> typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]:
+        if isinstance(data, autogl.data.graph.GeneralStaticGraph):
+            return self.__transform_homogeneous_static_graph(data)
+        elif (
+                hasattr(data, 'x') and isinstance(data.x, torch.Tensor) and
+                torch.is_tensor(data.x) and data.x.dim() == 2
+        ):
+            data.x = data.x[:, self._selection]
+            return data
+        else:
+            return data
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("FilterConstant")
+class FilterConstant(BaseFeatureSelector):
+    r"""drop constant features"""
+
+    def _fit(
+            self, data: typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]
+    ) -> typing.Union[autogl.data.graph.GeneralStaticGraph, typing.Any]:
+        if isinstance(data, autogl.data.graph.GeneralStaticGraph):
+            if 'x' in data.nodes.data:
+                feature: typing.Optional[np.ndarray] = data.nodes.data['x'].numpy()
+            elif 'feat' in data.nodes.data:
+                feature: typing.Optional[np.ndarray] = data.nodes.data['feat'].numpy()
+            else:
+                feature: typing.Optional[np.ndarray] = None
+        elif (
+                hasattr(data, 'x') and isinstance(data.x, torch.Tensor) and
+                torch.is_tensor(data.x) and data.x.dim() == 2
+        ):
+            feature: typing.Optional[np.ndarray] = data.x.numpy()
+        else:
+            feature: typing.Optional[np.ndarray] = None
+
+        if feature is not None and isinstance(feature, np.ndarray) and feature.ndim == 2:
+            self._selection: typing.Optional[torch.Tensor] = torch.from_numpy(
+                np.where(np.all(feature == feature[0, :], axis=0) == np.array(False))[0]
+            )
+        else:
+            self._selection: typing.Optional[torch.Tensor] = None
+        return data

--- a/autogl/module/preprocessing/feature_engineering/_selectors/_gbdt.py
+++ b/autogl/module/preprocessing/feature_engineering/_selectors/_gbdt.py
@@ -1,0 +1,140 @@
+import numpy as np
+import pandas as pd
+import torch
+import typing as _typing
+import autogl
+from autogl.data.graph import GeneralStaticGraph
+from ..._data_preprocessor_registry import DataPreprocessorUniversalRegistry
+import lightgbm
+from sklearn.model_selection import train_test_split
+from ._basic import BaseFeatureSelector
+
+
+def _gbdt_generator(
+        data: autogl.data.Data, fixlen: int = 1000,
+        params: _typing.Mapping[str, _typing.Any] = ...,
+        is_val: bool = True, train_val_ratio: float = 0.2,
+        **optimizer_parameters
+) -> _typing.Optional[np.ndarray]:
+    parameters: _typing.Dict[str, _typing.Any] = (
+        dict(params)
+        if (
+                params not in (Ellipsis, None) and
+                isinstance(params, _typing.Mapping)
+        )
+        else {
+            "boosting_type": "gbdt",
+            "verbosity": -1,
+            "random_state": 47,
+            "objective": "multiclass",
+            "metric": ["multi_logloss"],
+            "max_bin": 63,
+            "save_binary": True,
+            "num_threads": 20,
+            "num_leaves": 16,
+            "subsample": 0.9,
+            "subsample_freq": 1,
+            "colsample_bytree": 0.8,
+            # 'is_training_metric': True,
+            # 'metric_freq': 1,
+        }
+    )
+
+    num_classes: int = torch.max(data.y).item() + 1
+    parameters["num_class"] = num_classes
+    __optimizer_parameters = {
+        "num_boost_round": 100,
+        "early_stopping_rounds": 5,
+        "verbose_eval": False
+    }
+    __optimizer_parameters.update(optimizer_parameters)
+    if hasattr(data, "train_mask") and data.train_mask is not None and (
+            isinstance(data.train_mask, np.ndarray) or
+            isinstance(data.train_mask, torch.Tensor)
+    ):
+        x: np.ndarray = data.x[data.train_mask].numpy()
+        label: np.ndarray = data.y[data.train_mask].numpy()
+    else:
+        x: np.ndarray = data.x.numpy()
+        label: np.ndarray = data.y.numpy()
+        is_val: bool = False
+    _, num_features = x.shape
+    if num_features < fixlen:
+        return None
+
+    feature_index: np.ndarray = np.array(
+        [f"f{i}" for i in range(num_features)]
+    )
+    if is_val:
+        x_train, x_val, y_train, y_val = train_test_split(
+            x, label, test_size=train_val_ratio, stratify=label, random_state=47
+        )
+        dtrain = lightgbm.Dataset(x_train, label=y_train)
+        dval = lightgbm.Dataset(x_val, label=y_val)
+        clf = lightgbm.train(
+            train_set=dtrain, params=parameters, valid_sets=dval,
+            **__optimizer_parameters
+        )
+    else:
+        train_x = pd.DataFrame(x, columns=feature_index, index=None)
+        dtrain = lightgbm.Dataset(train_x, label=label)
+        clf = lightgbm.train(
+            train_set=dtrain, params=parameters,
+            **__optimizer_parameters
+        )
+
+    imp = np.array(list(clf.feature_importance()))
+    return np.argsort(imp)[-fixlen:]
+
+
+@DataPreprocessorUniversalRegistry.register_data_preprocessor("gbdt")
+class GBDTFeatureSelector(BaseFeatureSelector):
+    r"""simple wrapper of lightgbm , using importance ranking to select top-k features.
+
+    Parameters
+    ----------
+    fixlen : int
+        K for top-K important features.
+    """
+
+    def __init__(self, fixlen: int = 10, *args, **kwargs):
+        super(GBDTFeatureSelector, self).__init__()
+        self.__fixlen = fixlen
+        self.__args = args
+        self.__kwargs = kwargs
+
+    def _fit(self, homogeneous_static_graph: GeneralStaticGraph) -> GeneralStaticGraph:
+        if not isinstance(homogeneous_static_graph, GeneralStaticGraph):
+            raise TypeError
+        elif not (
+            homogeneous_static_graph.nodes.is_homogeneous and
+            homogeneous_static_graph.edges.is_homogeneous
+        ):
+            raise ValueError
+        if 'x' in homogeneous_static_graph.nodes.data:
+            features: torch.Tensor = homogeneous_static_graph.nodes.data['x']
+        elif 'feat' in homogeneous_static_graph.nodes.data:
+            features: torch.Tensor = homogeneous_static_graph.nodes.data['feat']
+        else:
+            raise ValueError("Node features not exists")
+        if 'y' in homogeneous_static_graph.nodes.data:
+            label: torch.Tensor = homogeneous_static_graph.nodes.data['y']
+        elif 'label' in homogeneous_static_graph.nodes.data:
+            label: torch.Tensor = homogeneous_static_graph.nodes.data['label']
+        else:
+            raise ValueError("Node label not exists")
+        if 'train_mask' in homogeneous_static_graph.nodes.data:
+            train_mask: _typing.Optional[torch.Tensor] = (
+                homogeneous_static_graph.nodes.data['train_mask']
+            )
+        else:
+            train_mask: _typing.Optional[torch.Tensor] = None
+        data = autogl.data.Data(
+            edge_index=homogeneous_static_graph.edges.connections,
+            x=features, y=label
+        )
+        data.train_mask = train_mask
+        self._selection = _gbdt_generator(
+            data, self.__fixlen, *self.__args, **self.__kwargs
+        )
+        return homogeneous_static_graph

--- a/autogl/module/preprocessing/structure_engineering/_structure_engineer.py
+++ b/autogl/module/preprocessing/structure_engineering/_structure_engineer.py
@@ -1,0 +1,5 @@
+from .. import _data_preprocessor
+
+
+class StructureEngineer(_data_preprocessor.DataPreprocessor):
+    ...


### PR DESCRIPTION
@wondergo2017 
I introduce a novel module `preprocessing` in the `autogl.module` package. For now the `preprocessing` module is composed of two submodules, i.e., `feature_engineering` and `structure_engineering`.
**The module of `preprocessing` is under developing (majorly by @wondergo2017 and me @CoreLeader ), thus all other modules should NOT use this `preprocessing` module until it is ready to be merged and called by `solver`.**

The base class for all preprocessing operations should be a subclass of `module.preprocessing.DataPreprocessor`, and overwrite the (protected) method `_fit` and `_transform`. See `module/preprocessing/_data_preprocessor/_data_preprocessor.py` for more details.
- both `_fit` and `_transform` get a `data` argument and should return a data as well. For `_transform` method, the `_transform` method should return a transformed data. A mock operation may looks like as following.
```python
class MockStructureEngineer(StructureEngineer):
    def _fit(self, data):
        return data
    def _transform(self, data):
          # This operation is extraordinary but this is just for a example.
        data.edge_index = torch.zeros(2, 256)
        return data
```
- The realized engineer must accept provided `data` as either instance of `autogl.data.graph.GeneralStaticGraph` or PyG-style data as input.
    - The conventional PyG-style data is a data object assume to have some conventional properties, e.g., `x`, `y`, and `edge_index`, etc.
    - (If other developers are not familiar with `autogl.data.graph.GeneralStaticGraph`, I am willing to assist)